### PR TITLE
Fix EventBus emit listener removal bug

### DIFF
--- a/chess-website-uml/public/src/util/Events.js
+++ b/chess-website-uml/public/src/util/Events.js
@@ -1,7 +1,20 @@
 export class EventBus {
   constructor(){ this.map = new Map(); }
   on(type, fn){ const a = this.map.get(type)||[]; a.push(fn); this.map.set(type,a); return () => this.off(type, fn); }
-  off(type, fn){ const a = this.map.get(type)||[]; const i=a.indexOf(fn); if (i>=0){ a.splice(i,1); this.map.set(type,a); } }
-  emit(type, payload){ const a = this.map.get(type)||[]; for (const fn of a) fn(payload); }
+  off(type, fn){
+    const a = this.map.get(type) || [];
+    const i = a.indexOf(fn);
+    if (i >= 0) {
+      a.splice(i, 1);
+      // Clean up empty arrays to avoid leaking keys
+      if (a.length > 0) this.map.set(type, a); else this.map.delete(type);
+    }
+  }
+
+  emit(type, payload){
+    const a = this.map.get(type) || [];
+    // Iterate over a snapshot so listeners can safely remove themselves
+    for (const fn of [...a]) fn(payload);
+  }
 }
 

--- a/tests/eventBus.test.js
+++ b/tests/eventBus.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventBus } from '../chess-website-uml/public/src/util/Events.js';
+
+test('listeners removed during emit do not skip remaining listeners', () => {
+  const bus = new EventBus();
+  const calls = [];
+  let offA;
+  const fnA = () => {
+    calls.push('a');
+    offA();
+  };
+  offA = bus.on('evt', fnA);
+  bus.on('evt', () => {
+    calls.push('b');
+  });
+  bus.emit('evt');
+  bus.emit('evt');
+  assert.deepStrictEqual(calls, ['a', 'b', 'b']);
+});


### PR DESCRIPTION
## Summary
- ensure EventBus emits to all listeners even when some remove themselves
- clean up listener storage after removing callbacks
- add regression test for EventBus emit behaviour

## Testing
- `node --test tests/eventBus.test.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de412a534832e83ce1e409dec6885