### PR TITLE
Pause clock interval when time runs out

### DIFF
--- a/chess-website-uml/public/src/core/Clock.js
+++ b/chess-website-uml/public/src/core/Clock.js
@@ -51,10 +51,20 @@ export class Clock {
     if (!this.ticking) return;
     if (this.turn==='w'){
       this.white -= 100;
-      if (this.white <= 0){ this.white = 0; this.ticking = false; this.onFlag && this.onFlag('w'); }
+      if (this.white <= 0){
+        this.white = 0;
+        this.ticking = false;
+        this.pause(); // Clear interval to avoid background work
+        this.onFlag && this.onFlag('w');
+      }
     } else {
       this.black -= 100;
-      if (this.black <= 0){ this.black = 0; this.ticking = false; this.onFlag && this.onFlag('b'); }
+      if (this.black <= 0){
+        this.black = 0;
+        this.ticking = false;
+        this.pause(); // Clear interval to avoid background work
+        this.onFlag && this.onFlag('b');
+      }
     }
     this.onTick && this.onTick();
   }


### PR DESCRIPTION
## Summary
- stop active timer when a player's clock hits zero to prevent background work

## Testing
- `node --check chess-website-uml/public/src/core/Clock.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de6e972c4832ea9581b182c8f82b7