### PR TITLE
Add clock timeout test and fix timer clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 for fun coding project for an open source chess website where the processing is fully client-side and without any external dependencies, coded in html, css &amp; js
 
 this is mainly a project testing the functionality and playing with the new "gpt-5 thinking"-model, all code is written by chatgpt using a plus subscription.
+
+## Running tests
+
+Run the test suite with Node's built-in test runner:
+
+```sh
+node --test
+```

--- a/chess-website-uml/public/src/core/Clock.js
+++ b/chess-website-uml/public/src/core/Clock.js
@@ -51,10 +51,20 @@ export class Clock {
     if (!this.ticking) return;
     if (this.turn==='w'){
       this.white -= 100;
-      if (this.white <= 0){ this.white = 0; this.ticking = false; this.onFlag && this.onFlag('w'); }
+      if (this.white <= 0){
+        this.white = 0;
+        this.ticking = false;
+        if (this.timer) { clearInterval(this.timer); this.timer = null; }
+        this.onFlag && this.onFlag('w');
+      }
     } else {
       this.black -= 100;
-      if (this.black <= 0){ this.black = 0; this.ticking = false; this.onFlag && this.onFlag('b'); }
+      if (this.black <= 0){
+        this.black = 0;
+        this.ticking = false;
+        if (this.timer) { clearInterval(this.timer); this.timer = null; }
+        this.onFlag && this.onFlag('b');
+      }
     }
     this.onTick && this.onTick();
   }

--- a/chess-website-uml/public/src/core/Clock.test.js
+++ b/chess-website-uml/public/src/core/Clock.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { Clock } from './Clock.js';
+
+test('clock flags and clears timer on timeout', async () => {
+  const clock = new Clock();
+  clock.base = 100;
+  clock.white = 100;
+  clock.black = 100;
+
+  const flagged = await new Promise(resolve => {
+    clock.onFlag = resolve;
+    clock.start();
+  });
+
+  assert.strictEqual(flagged, 'w');
+  assert.strictEqual(clock.timer, null);
+});


### PR DESCRIPTION
## Summary
- add node:test for Clock to ensure flag callback fires and timer is cleared when time expires
- clear Clock timer when a side flags
- document how to run tests with `node --test`

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689de6f9fb0c832e8d1fa11cb2a310f0