### PR TITLE
Improve UI and hook up PGN/FEN buttons

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -103,6 +103,20 @@
     .status{margin-top:6px; min-height:24px}
     .badge{display:inline-flex; min-width:10px; height:18px; padding:0 6px; align-items:center; justify-content:center; border-radius:999px; background:#112033; border:1px solid #27405c; font-size:12px; color:#cfe2ff}
 
+    /* Buttons */
+    button{
+      background:var(--accent);
+      color:var(--bg);
+      border:none;
+      border-radius:6px;
+      padding:4px 10px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background .2s, transform .1s;
+    }
+    button:hover{ background:#5b97f0; }
+    button:active{ transform:translateY(1px); }
+
     /* Game info button + popover (App.js injects the button; styles here) */
     .game-info-trigger{
       position:absolute; top:12px; right:12px;

--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -27,6 +27,8 @@ class App {
     this.sideSel = qs('#side');
     this.flipBtn = qs('#flip');
     this.newGameBtn = qs('#newGame');
+    this.pgnText = qs('#pgnText');
+    this.fenText = qs('#fenText');
 
     // Engine knobs
     this.elo = qs('#elo'); this.eloVal = qs('#eloVal');
@@ -191,6 +193,44 @@ class App {
     qs('#analyzeBtn').addEventListener('click', () => this.requestAnalysis());
     qs('#hintBtn').addEventListener('click', () => this.requestHint());
     qs('#stopBtn').addEventListener('click', () => this.engine.stop());
+
+    // PGN / FEN helpers
+    qs('#copyPgn').addEventListener('click', () => {
+      const pgn = this.game.pgn();
+      this.pgnText.value = pgn;
+      try { navigator.clipboard?.writeText(pgn); this.engineStatus.textContent = 'PGN copied'; }
+      catch {}
+    });
+    qs('#loadPgn').addEventListener('click', () => {
+      const txt = this.pgnText.value.trim();
+      if (!txt) return;
+      if (this.game.loadPgn(txt)) {
+        this.exitReview();
+        this.syncBoard();
+        this.refreshAll();
+        this.engineStatus.textContent = 'PGN loaded';
+      } else {
+        this.engineStatus.textContent = 'Invalid PGN';
+      }
+    });
+    qs('#exportFen').addEventListener('click', () => {
+      const fen = this.game.fen();
+      this.fenText.value = fen;
+      try { navigator.clipboard?.writeText(fen); this.engineStatus.textContent = 'FEN copied'; }
+      catch {}
+    });
+    qs('#importFen').addEventListener('click', () => {
+      const txt = this.fenText.value.trim();
+      if (!txt) return;
+      if (this.game.load(txt)) {
+        this.exitReview();
+        this.syncBoard();
+        this.refreshAll();
+        this.engineStatus.textContent = 'FEN loaded';
+      } else {
+        this.engineStatus.textContent = 'Invalid FEN';
+      }
+    });
   }
 
   // === Review hotkeys & click-to-exit ===

--- a/chess-website-uml/public/src/core/Game.js
+++ b/chess-website-uml/public/src/core/Game.js
@@ -8,6 +8,7 @@ export class Game {
   }
   reset(){ this.ch.reset(); this.redo.length = 0; }
   load(fen){ const ok = this.ch.load(fen); if (ok) this.redo.length = 0; return ok; }
+  loadPgn(pgn){ const ok = this.ch.loadPgn(pgn); if (ok) this.redo.length = 0; return ok; }
   fen(){ return this.ch.fen(); }
   pgn(){ return this.ch.pgn(); }
   turn(){ return this.ch.turn(); }


### PR DESCRIPTION
## Summary
- Style all buttons with a reusable accent look
- Wire PGN and FEN buttons to copy/load game data
- Expose `loadPgn` helper on the Game wrapper

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689df403a32c832e93a99d0a07d52f84