### PR TITLE
feat: add dynamic time manager

### DIFF
--- a/chess-website-uml/public/src/engine/TimeManager.js
+++ b/chess-website-uml/public/src/engine/TimeManager.js
@@ -1,0 +1,43 @@
+import { Chess } from "../vendor/chess.mjs";
+
+export function estimateComplexity(fen) {
+  const ch = new Chess(fen);
+  const moves = ch.moves({ verbose: true });
+  let complexity = moves.length;
+  let tactical = 0;
+  for (const mv of moves) {
+    const flags = mv.flags || "";
+    if (
+      flags.includes("c") ||
+      flags.includes("e") ||
+      flags.includes("k") ||
+      flags.includes("p") ||
+      (mv.san && mv.san.includes("+"))
+    ) {
+      tactical++;
+    }
+  }
+  return complexity + tactical;
+}
+
+export function allocateMoveTime({
+  timeLeftMs,
+  incrementMs = 0,
+  movesToGo = 30,
+  complexity = 20,
+}) {
+  const reserve = timeLeftMs * 0.05; // keep 5% buffer
+  const remaining = Math.max(0, timeLeftMs - reserve);
+  let base = remaining / Math.max(1, movesToGo);
+  base += incrementMs * 0.8; // use most of increment
+
+  let factor = 1;
+  if (complexity >= 40) factor = 2;
+  else if (complexity >= 30) factor = 1.5;
+  else if (complexity >= 20) factor = 1.2;
+
+  let alloc = base * factor;
+  alloc = Math.min(alloc, remaining);
+  if (timeLeftMs < 1000) alloc = Math.min(alloc, timeLeftMs * 0.5); // panic mode
+  return Math.max(1, Math.round(alloc));
+}

--- a/chess-website-uml/public/src/engine/WorkerEngine.js
+++ b/chess-website-uml/public/src/engine/WorkerEngine.js
@@ -1,40 +1,82 @@
-import { Engine } from './Engine.js';
+import { Engine } from "./Engine.js";
+import { allocateMoveTime, estimateComplexity } from "./TimeManager.js";
 
 // Uses our JS mini-engine in a Module Worker
 export class WorkerEngine extends Engine {
-  constructor(){
+  constructor() {
     super();
     this.worker = new Worker(
-      new URL('../workers/mini-engine.js', import.meta.url),
-      { type: 'module' } // IMPORTANT: module worker
+      new URL("../workers/mini-engine.js", import.meta.url),
+      { type: "module" }, // IMPORTANT: module worker
     );
     this.req = 0;
     this.waiting = new Map();
     this.worker.onmessage = (e) => {
-      const msg = e.data||{};
+      const msg = e.data || {};
       const pend = this.waiting.get(msg.id);
       if (!pend) return;
-      if (msg.type === 'analysis') pend.resolve(msg.lines);
-      else if (msg.type === 'bestmove') pend.resolve(msg.uci);
-      else pend.reject(new Error('Unknown response'));
+      if (msg.type === "analysis") pend.resolve(msg.lines);
+      else if (msg.type === "bestmove") pend.resolve(msg.uci);
+      else pend.reject(new Error("Unknown response"));
       this.waiting.delete(msg.id);
     };
   }
 
-  _postAwait(payload){
+  _postAwait(payload) {
     const id = ++this.req;
     payload.id = id;
-    const p = new Promise((resolve,reject)=> this.waiting.set(id, {resolve,reject}));
+    const p = new Promise((resolve, reject) =>
+      this.waiting.set(id, { resolve, reject }),
+    );
     this.worker.postMessage(payload);
     return p;
   }
 
-  analyze(fen, { depth=6, multipv=2, timeMs=300 } = {}){
-    return this._postAwait({ type: 'analyze', fen, depth, multipv, timeMs });
+  analyze(
+    fen,
+    {
+      depth = 6,
+      multipv = 2,
+      timeMs = 300,
+      timeLeftMs,
+      incrementMs = 0,
+      movesToGo = 30,
+    } = {},
+  ) {
+    if (typeof timeLeftMs === "number") {
+      const comp = estimateComplexity(fen);
+      timeMs = allocateMoveTime({
+        timeLeftMs,
+        incrementMs,
+        movesToGo,
+        complexity: comp,
+      });
+    }
+    return this._postAwait({ type: "analyze", fen, depth, multipv, timeMs });
   }
-  play(fen, { elo=1600, depthCap=6, timeMs=300 } = {}){
-    return this._postAwait({ type: 'play', fen, elo, depthCap, timeMs });
+  play(
+    fen,
+    {
+      elo = 1600,
+      depthCap = 6,
+      timeMs = 300,
+      timeLeftMs,
+      incrementMs = 0,
+      movesToGo = 30,
+    } = {},
+  ) {
+    if (typeof timeLeftMs === "number") {
+      const comp = estimateComplexity(fen);
+      timeMs = allocateMoveTime({
+        timeLeftMs,
+        incrementMs,
+        movesToGo,
+        complexity: comp,
+      });
+    }
+    return this._postAwait({ type: "play", fen, elo, depthCap, timeMs });
   }
-  stop(){ this.worker.postMessage({ type: 'stop' }); }
+  stop() {
+    this.worker.postMessage({ type: "stop" });
+  }
 }
-

--- a/tests/timeManager.test.js
+++ b/tests/timeManager.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  allocateMoveTime,
+  estimateComplexity,
+} from "../chess-website-uml/public/src/engine/TimeManager.js";
+
+const START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+const SIMPLE_FEN = "8/8/8/8/8/8/6k1/K7 w - - 0 1";
+
+test("complex positions receive more time", () => {
+  const high = estimateComplexity(START_FEN);
+  const low = estimateComplexity(SIMPLE_FEN);
+  assert.ok(high > low);
+  const tHigh = allocateMoveTime({
+    timeLeftMs: 60000,
+    complexity: high,
+    movesToGo: 30,
+  });
+  const tLow = allocateMoveTime({
+    timeLeftMs: 60000,
+    complexity: low,
+    movesToGo: 30,
+  });
+  assert.ok(tHigh > tLow);
+});
+
+test("panic mode limits time usage when very low on clock", () => {
+  const high = estimateComplexity(START_FEN);
+  const t = allocateMoveTime({
+    timeLeftMs: 500,
+    complexity: high,
+    movesToGo: 30,
+  });
+  assert.ok(t <= 250);
+});


### PR DESCRIPTION
## Summary
- add time manager with simple complexity heuristic
- allocate time dynamically based on clock and position
- cover time manager logic with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df3dc7dc0832e9925eaa58a6a045a