### PR TITLE
Add gentle move and capture sounds

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -6,6 +6,7 @@ import { PuzzleService } from '../puzzles/PuzzleService.js';
 import { PuzzleUI } from '../puzzles/PuzzleUI.js';
 import { ClockPanel } from '../ui/ClockPanel.js';
 import { detectOpening } from '../engine/Openings.js';
+import { Sounds } from '../util/Sounds.js';
 
 const qs = (s) => document.querySelector(s);
 
@@ -51,6 +52,7 @@ class App {
     this.game = new Game();
     this.clock = new Clock();
     this.engine = new WorkerEngine();
+    this.sounds = new Sounds();
 
     // Clock UI
     this.clockPanel = new ClockPanel({ clock: this.clock, els: clockEls });
@@ -88,7 +90,8 @@ class App {
         randomFromPackBtn: qs('#randomFromPack'), nextPuzzleBtn: qs('#nextPuzzle'),
         hintBtn: qs('#puzzleHint'), puzzleInfo: qs('#puzzleInfo'), puzzleStatus: qs('#puzzleStatus')
       },
-      onStateChanged: () => { this.syncBoard(); this.refreshAll(); }
+      onStateChanged: () => { this.syncBoard(); this.refreshAll(); },
+      onMove: (mv) => this.sounds.play(mv?.captured ? 'capture' : 'move')
     });
 
     // Floating info popover
@@ -318,6 +321,7 @@ class App {
     if (this.inReview || this.gameOver) return false; // safety net
     const mv = this.game.move({ from, to, promotion: promotion || 'q' });
     if (!mv) return false;
+    this.sounds.play(mv.captured ? 'capture' : 'move');
 
     if (this.modeSel.value === 'play') { this.clock.onMoveApplied(); this.clockPanel.startIfNotRunning(); }
     if (this.modeSel.value === 'puzzle') {
@@ -369,6 +373,7 @@ class App {
           this.clock.onMoveApplied?.();
           const last = this.game.historyVerbose?.().slice(-1)[0] || mv;
           if (last?.from && last?.to) this.ui.drawArrowUci(last.from + last.to + (last.promotion||''), true);
+          this.sounds.play(mv.captured ? 'capture' : 'move');
           this.syncBoard(); this.refreshAll();
           this.maybeCelebrate();
           this.checkGameOver();
@@ -387,8 +392,9 @@ class App {
         incrementMs: this.clock.inc
       });
       if (uci) {
-        this.game.moveUci(uci);
+        const mv = this.game.moveUci(uci);
         if (this.modeSel.value === 'play') this.clock.onMoveApplied();
+        this.sounds.play(mv?.captured ? 'capture' : 'move');
         this.syncBoard(); this.refreshAll();
         this.ui.drawArrowUci(uci, true);
         this.maybeCelebrate();

--- a/chess-website-uml/public/src/puzzles/PuzzleUI.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleUI.js
@@ -5,12 +5,13 @@ import { adaptLichessPuzzle } from './PuzzleModel.js';
 function on(el, type, fn){ if (el) el.addEventListener(type, fn); }
 
 export class PuzzleUI {
-  constructor({ game, ui, service, dom, onStateChanged }){
+  constructor({ game, ui, service, dom, onStateChanged, onMove }) {
     this.game = game;
     this.ui = ui;
     this.svc = service;
     this.dom = dom || {};
     this.onStateChanged = onStateChanged || (()=>{});
+    this.onMove = onMove || (()=>{});
 
     this.current = null;
     this.index = 0;
@@ -146,7 +147,8 @@ export class PuzzleUI {
         const tmp2 = new Chess(this.game.fen());
         const rm = tmp2.move(reply);
         if (rm){
-          this.game.moveSan(reply);
+          const applied = this.game.moveSan(reply);
+          this.onMove(applied);
           this.index++;
           this.onStateChanged();
           if (this.dom?.puzzleStatus) this.dom.puzzleStatus.innerHTML = `<span style="color:#8aa0b6">Your move…</span>`;

--- a/chess-website-uml/public/src/util/Sounds.js
+++ b/chess-website-uml/public/src/util/Sounds.js
@@ -1,0 +1,28 @@
+export class Sounds {
+  constructor() {
+    this.ctx = null;
+  }
+
+  play(name) {
+    try {
+      const ctx = this.ctx || (this.ctx = new (window.AudioContext || window.webkitAudioContext)());
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      gain.gain.value = 0.1;
+      osc.type = 'sine';
+      if (name === 'move') {
+        osc.frequency.value = 600;
+      } else if (name === 'capture') {
+        osc.frequency.value = 420;
+      } else {
+        return;
+      }
+      osc.connect(gain).connect(ctx.destination);
+      const dur = name === 'capture' ? 0.4 : 0.25;
+      osc.start();
+      osc.stop(ctx.currentTime + dur);
+    } catch {
+      // ignore playback errors
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace binary audio assets with synthesized sine-wave tones
- play move and capture sounds for user, engine, and puzzle moves

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e43642748832ea4d13c18b4bde530