### PR TITLE
Replace flip control with switch-side restart button

### DIFF
--- a/chess-website-uml/public/css/base.css
+++ b/chess-website-uml/public/css/base.css
@@ -40,3 +40,15 @@ header h1{font-size:28px;margin:0;text-align:center}
 /* Simple helpers */
 .status{min-height:22px}
 .moves{max-height:220px; overflow:auto}
+
+/* Switch color / restart button */
+.switch-btn{
+  background:#000;
+  color:#fff;
+  padding:6px 10px;
+  border:1px solid #000;
+  border-radius:8px;
+  cursor:pointer;
+  transition:transform 0.1s;
+}
+.switch-btn.confirm{ transform:scale(1.1); }

--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -217,14 +217,13 @@
             <option value="puzzle">Puzzles</option>
           </select>
 
-          <label for="side">Your side</label>
-          <select id="side">
+          <label for="side" style="display:none">Your side</label>
+          <select id="side" style="display:none">
             <option value="white">White</option>
             <option value="black">Black</option>
           </select>
 
-          <button id="flip">Flip</button>
-          <button id="newGame">New Game</button>
+          <button id="switchSide" class="switch-btn">Switch to black and restart</button>
           <span class="badge" id="sabBadge" title="SharedArrayBuffer status"></span>
         </div>
 


### PR DESCRIPTION
## Summary
- Remove unused board-flip control and keep board oriented to player's side
- Add black "switch side and restart" button with confirm-to-restart behavior
- Style new switch button and update game logic to restart with opposite color

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e4bf11ac8832e970185e65015c0ab