### PR TITLE
Ensure arrow snapshots stay aligned with move history

### DIFF
--- a/chess-website-uml/public/src/ui/DrawOverlay.js
+++ b/chess-website-uml/public/src/ui/DrawOverlay.js
@@ -280,15 +280,9 @@
 
   DrawOverlay.prototype.recordSnapshot = function(){
     const snap = this.getUserDrawings();
-    // Avoid pushing duplicates if same as last
-    const last = this._snapshots[this._cursor-1];
-    const asJson = JSON.stringify(snap);
-    const lastJson = last ? JSON.stringify(last) : '';
-    if (asJson !== lastJson){
-      this._snapshots.splice(this._cursor); // drop anything ahead
-      this._snapshots.push(snap);
-      this._cursor = this._snapshots.length;
-    }
+    this._snapshots.splice(this._cursor); // drop anything ahead
+    this._snapshots.push(snap);
+    this._cursor = this._snapshots.length;
   };
 
   DrawOverlay.prototype.finishRightDrag = function(e){


### PR DESCRIPTION
## Summary
- Always record drawing snapshots in DrawOverlay so navigation through previous drawings stays in sync with move history

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error in OpeningBook.js)*
- `npx eslint chess-website-uml/public/src/ui/DrawOverlay.js`


------
https://chatgpt.com/codex/tasks/task_e_689e54605c70832e966a909bd1061ad8