### PR TITLE
Add chessboard favicon

### DIFF
--- a/chess-website-uml/public/favicon.svg
+++ b/chess-website-uml/public/favicon.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+<rect width="64" height="64" fill="#3a475b"/>
+<rect x="8" y="0" width="8" height="8" fill="#2a3443"/>
+<rect x="24" y="0" width="8" height="8" fill="#2a3443"/>
+<rect x="40" y="0" width="8" height="8" fill="#2a3443"/>
+<rect x="56" y="0" width="8" height="8" fill="#2a3443"/>
+<rect x="0" y="8" width="8" height="8" fill="#2a3443"/>
+<rect x="16" y="8" width="8" height="8" fill="#2a3443"/>
+<rect x="32" y="8" width="8" height="8" fill="#2a3443"/>
+<rect x="48" y="8" width="8" height="8" fill="#2a3443"/>
+<rect x="8" y="16" width="8" height="8" fill="#2a3443"/>
+<rect x="24" y="16" width="8" height="8" fill="#2a3443"/>
+<rect x="40" y="16" width="8" height="8" fill="#2a3443"/>
+<rect x="56" y="16" width="8" height="8" fill="#2a3443"/>
+<rect x="0" y="24" width="8" height="8" fill="#2a3443"/>
+<rect x="16" y="24" width="8" height="8" fill="#2a3443"/>
+<rect x="32" y="24" width="8" height="8" fill="#2a3443"/>
+<rect x="48" y="24" width="8" height="8" fill="#2a3443"/>
+<rect x="8" y="32" width="8" height="8" fill="#2a3443"/>
+<rect x="24" y="32" width="8" height="8" fill="#2a3443"/>
+<rect x="40" y="32" width="8" height="8" fill="#2a3443"/>
+<rect x="56" y="32" width="8" height="8" fill="#2a3443"/>
+<rect x="0" y="40" width="8" height="8" fill="#2a3443"/>
+<rect x="16" y="40" width="8" height="8" fill="#2a3443"/>
+<rect x="32" y="40" width="8" height="8" fill="#2a3443"/>
+<rect x="48" y="40" width="8" height="8" fill="#2a3443"/>
+<rect x="8" y="48" width="8" height="8" fill="#2a3443"/>
+<rect x="24" y="48" width="8" height="8" fill="#2a3443"/>
+<rect x="40" y="48" width="8" height="8" fill="#2a3443"/>
+<rect x="56" y="48" width="8" height="8" fill="#2a3443"/>
+<rect x="0" y="56" width="8" height="8" fill="#2a3443"/>
+<rect x="16" y="56" width="8" height="8" fill="#2a3443"/>
+<rect x="32" y="56" width="8" height="8" fill="#2a3443"/>
+<rect x="48" y="56" width="8" height="8" fill="#2a3443"/>
+<text x="32.0" y="41.6" text-anchor="middle" font-size="44.8" font-family="sans-serif" fill="#6ba7ff" font-weight="bold">Z</text>
+</svg>

--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -5,6 +5,7 @@
   <title>Chess by Sam</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#0f1216" />
+  <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
 
   <style>
     :root{


### PR DESCRIPTION
## Summary
- add favicon link to index.html
- create SVG favicon with board colors and centered Z

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e557e1c04832ea0d0dc780e78d560