### PR TITLE
Ensure arrow snapshots stay aligned with move history

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -12,6 +12,8 @@ const qs = (s) => document.querySelector(s);
 
 class App {
   constructor() {
+    window.app = this;
+
     // DOM
     this.boardEl = qs('#board');
     this.arrowSvg = qs('#arrowSvg');
@@ -516,6 +518,9 @@ class App {
   syncBoard(){
     this.ui.setOrientation(this.sideSel.value);
     this.ui.setFen(this.getActiveFen());
+    const ply = this.inReview ? this.reviewPly : this.getSanHistory().length;
+    const inst = window.DrawOverlayInstance;
+    if (inst && typeof inst.restoreSnapshotForPly === 'function') inst.restoreSnapshotForPly(ply);
   }
 
   refreshAll(){

--- a/chess-website-uml/public/src/ui/DrawOverlay.js
+++ b/chess-website-uml/public/src/ui/DrawOverlay.js
@@ -128,9 +128,8 @@
     this.cell = 0;
     this.orientation = (boardEl.getAttribute('data-orientation') || boardEl.dataset?.orientation) === 'black' ? 'black' : 'white';
 
-    // simple snapshot stack (for ArrowLeft/ArrowRight)
-    this._snapshots = []; // array of {arrows:[...], circles:[...]}
-    this._cursor = 0;     // points *after* the current state (like history)
+    // snapshots keyed by move ply
+    this._snapsByPly = new Map();
 
     this.updateMetrics();
     this.resizeOverlay();
@@ -139,24 +138,6 @@
 
     boardEl.addEventListener('contextmenu', (e)=> e.preventDefault(), true);
     window.addEventListener('resize', ()=>{ this.updateMetrics(); this.resizeOverlay(); this.redrawAll(); });
-
-    // keyboard: restore snapshots on arrow keys
-    window.addEventListener('keydown', (e)=>{
-      if (e.key === 'ArrowLeft'){
-        if (this._cursor > 0){
-          this._cursor--;
-          const snap = this._snapshots[this._cursor];
-          this.setUserDrawings(snap);
-        }
-      } else if (e.key === 'ArrowRight'){
-        if (this._cursor < this._snapshots.length){
-          this._cursor++;
-          // Forward typically means "no helpers"; clear to that snapshot if it exists, else empty.
-          const snap = this._snapshots[this._cursor] || {arrows:[],circles:[]};
-          this.setUserDrawings(snap);
-        }
-      }
-    });
   }
 
   DrawOverlay.prototype.updateMetrics = function(){
@@ -278,17 +259,22 @@
     });
   };
 
-  DrawOverlay.prototype.recordSnapshot = function(){
-    const snap = this.getUserDrawings();
-    // Avoid pushing duplicates if same as last
-    const last = this._snapshots[this._cursor-1];
-    const asJson = JSON.stringify(snap);
-    const lastJson = last ? JSON.stringify(last) : '';
-    if (asJson !== lastJson){
-      this._snapshots.splice(this._cursor); // drop anything ahead
-      this._snapshots.push(snap);
-      this._cursor = this._snapshots.length;
+  DrawOverlay.prototype.currentPly = function(){
+    const app = window.app;
+    if (app){
+      return app.inReview ? app.reviewPly : app.getSanHistory().length;
     }
+    return 0;
+  };
+
+  DrawOverlay.prototype.recordSnapshot = function(){
+    const ply = this.currentPly();
+    this._snapsByPly.set(ply, this.getUserDrawings());
+  };
+
+  DrawOverlay.prototype.restoreSnapshotForPly = function(ply){
+    const snap = this._snapsByPly.get(ply);
+    this.setUserDrawings(snap || { arrows:[], circles:[] });
   };
 
   DrawOverlay.prototype.finishRightDrag = function(e){


### PR DESCRIPTION
## Summary
- Track user drawings by move ply and provide helpers to restore snapshots when revisiting positions
- Sync board updates with stored snapshots so navigating the move list keeps arrows tied to the correct game state

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error in OpeningBook.js)*
- `npx eslint chess-website-uml/public/src/ui/DrawOverlay.js chess-website-uml/public/src/app/App.js`

------
https://chatgpt.com/codex/tasks/task_e_689e54605c70832e966a909bd1061ad8