### PR TITLE
Remove SharedArrayBuffer badge

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -225,7 +225,6 @@
           </select>
 
           <button id="switchSide" class="switch-btn">Switch to black and restart</button>
-          <span class="badge" id="sabBadge" title="SharedArrayBuffer status"></span>
         </div>
 
         <div class="row">

--- a/chess-website-uml/public/src/engine/EngineTuner.js
+++ b/chess-website-uml/public/src/engine/EngineTuner.js
@@ -16,8 +16,7 @@ export class EngineTuner {
     // Badges
     updateBadges({
       threadsBadge: this.dom.threadsBadge,
-      hashBadge: this.dom.hashBadge,
-      sabBadge: this.dom.sabBadge
+      hashBadge: this.dom.hashBadge
     }, this.caps);
 
     // Wire events

--- a/chess-website-uml/public/src/engine/RuntimeCaps.js
+++ b/chess-website-uml/public/src/engine/RuntimeCaps.js
@@ -15,11 +15,7 @@ export function detectCaps() {
   return { sabEnabled, threads, hashMB, cores, deviceMemoryGB: dm };
 }
 
-export function updateBadges({ threadsBadge, hashBadge, sabBadge }, caps) {
+export function updateBadges({ threadsBadge, hashBadge }, caps) {
   if (threadsBadge) threadsBadge.textContent = `Threads: ${caps.threads}`;
   if (hashBadge)    hashBadge.textContent    = `Hash: ${caps.hashMB}MB`;
-  if (sabBadge) {
-    sabBadge.textContent = caps.sabEnabled ? 'SAB: enabled' : 'SAB: disabled (need COOP/COEP)';
-    sabBadge.className = `badge ${caps.sabEnabled ? '' : 'warn'}`;
-  }
 }

--- a/chess-website-uml/public/src/engine/boot.js
+++ b/chess-website-uml/public/src/engine/boot.js
@@ -20,7 +20,6 @@ function collectDom(){
     // badges
     threadsBadge: $('threadsBadge'),
     hashBadge: $('hashBadge'),
-    sabBadge: $('sabBadge'),
     // misc
     useBook: $('useBook')
   };


### PR DESCRIPTION
## Summary
- Remove the SharedArrayBuffer badge element from the UI
- Drop sabBadge references from bootstrap, engine tuner, and runtime capability code

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e5ab940f8832e8f8f6a8e2d162774