### PR TITLE
Fix board orientation when switching sides

### DIFF
--- a/chess-website-uml/public/src/ui/BoardUI.js
+++ b/chess-website-uml/public/src/ui/BoardUI.js
@@ -367,7 +367,9 @@ export class BoardUI {
     let idx = 0;
     for (let rank=8; rank>=1; rank--){
       for (let file=0; file<8; file++, idx++){
-        const sq = `${FILES[file]}${rank}`;
+        const sq = (this.orientation === 'white')
+          ? `${FILES[file]}${rank}`
+          : `${FILES[7 - file]}${9 - rank}`;
         const el = squares[idx];
         const piece = pos[sq];
 


### PR DESCRIPTION
## Summary
- ensure board squares map correctly when orientation is black so the board flips when switching sides

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e5f2b5f60832e960c420878ba8751