### PR TITLE
Simplify engine play UI by removing analysis controls

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -232,13 +232,6 @@
         </div>
 
         <div class="row">
-          <button class="button" id="analyzeBtn">Analyze</button>
-          <button class="button" id="hintBtn">Hint</button>
-          <button class="button" id="stopBtn">Stop</button>
-          <span class="muted" id="autoSummary"></span>
-        </div>
-
-        <div class="row">
           <div class="pv" id="pvBox"></div>
         </div>
         <div class="row">

--- a/chess-website-uml/public/src/engine/EngineTuner.js
+++ b/chess-website-uml/public/src/engine/EngineTuner.js
@@ -65,7 +65,6 @@ export class EngineTuner {
     if (!this.dom) return;
     if (this.dom.depth){ this.dom.depth.value = p.depth; this.dom.depthVal.textContent = String(p.depth); }
     if (this.dom.multipv){ this.dom.multipv.value = p.multipv; this.dom.multipvVal.textContent = String(p.multipv); }
-    if (this.dom.autoSummary){ this.dom.autoSummary.textContent = `→ depth ${p.depth}, think ${p.movetime}ms, MultiPV ${p.multipv}`; }
   }
 
   _setKnobsEnabled(disabled){
@@ -103,7 +102,7 @@ export class EngineTuner {
 
     const auto = !!this.dom.auto?.checked;
     if (auto){ this._applyToSliders(p); this._setKnobsEnabled(true); }
-    else { if (this.dom.autoSummary) this.dom.autoSummary.textContent = ''; this._setKnobsEnabled(false); }
+    else { this._setKnobsEnabled(false); }
 
     const multipv = auto ? p.multipv : (+this.dom.multipv?.value || p.multipv);
     const depth   = auto ? p.depth   : (+this.dom.depth?.value   || p.depth);

--- a/chess-website-uml/public/src/engine/boot.js
+++ b/chess-website-uml/public/src/engine/boot.js
@@ -13,7 +13,6 @@ function collectDom(){
     // controls
     mode: $('mode'),
     auto: $('autoTune'),
-    autoSummary: $('autoSummary'),
     elo: $('elo'), eloVal: $('eloVal'),
     depth: $('depth'), depthVal: $('depthVal'),
     multipv: $('multipv'), multipvVal: $('multipvVal'),


### PR DESCRIPTION
## Summary
- Remove Analyze, Hint, and Stop buttons from engine play mode
- Drop estimated strength display and supporting code
- Clean up engine tuner references to auto strength summaries

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e5f0ad590832e986be9005ab6fc10