### PR TITLE
fix drag orientation bug

### DIFF
--- a/chess-website-uml/public/src/ui/BoardUI.js
+++ b/chess-website-uml/public/src/ui/BoardUI.js
@@ -371,6 +371,7 @@ export class BoardUI {
           ? `${FILES[file]}${rank}`
           : `${FILES[7 - file]}${9 - rank}`;
         const el = squares[idx];
+        el.dataset.square = sq;
         const piece = pos[sq];
 
         // clear

--- a/tests/boardui.test.js
+++ b/tests/boardui.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// helper to create a barebones square element
+function makeSquare() {
+  return {
+    dataset: { square: '' },
+    innerHTML: '',
+    classList: { add() {}, remove() {} },
+    removeAttribute() {},
+    setAttribute() {},
+    querySelector() { return null; },
+    style: {}
+  };
+}
+
+test('setOrientation updates square dataset for black view', async () => {
+  globalThis.document = {
+    getElementById() { return null; },
+    createElement() {
+      return {
+        setAttribute() {},
+        appendChild() {},
+        style: {},
+        textContent: '',
+        id: ''
+      };
+    },
+    head: { appendChild() {} }
+  };
+
+  const { BoardUI } = await import('../chess-website-uml/public/src/ui/BoardUI.js');
+
+  const files = ['a','b','c','d','e','f','g','h'];
+  const squares = [];
+  for (let r = 8; r >= 1; r--) {
+    for (let f = 0; f < 8; f++) {
+      const el = makeSquare();
+      el.dataset.square = `${files[f]}${r}`; // initial white orientation
+      squares.push(el);
+    }
+  }
+
+  const boardEl = {
+    querySelectorAll(sel) { return sel === '.sq' ? squares : []; },
+    style: { setProperty() {} },
+    clientWidth: 400,
+    clientHeight: 400,
+    appendChild() {},
+    querySelector() { return null; }
+  };
+
+  const ui = Object.create(BoardUI.prototype);
+  ui.boardEl = boardEl;
+  ui._pos = {};
+  ui.resizeOverlayViewBox = () => {};
+  ui.orientation = 'white';
+
+  // Render initial orientation then flip
+  ui.renderPosition();
+  ui.setOrientation('black');
+
+  assert.equal(squares[0].dataset.square, 'h1');
+});


### PR DESCRIPTION
## Summary
- ensure each square's dataset is updated when board orientation flips
- add regression test confirming square mapping after switching to black

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e605572ac832e9fc2b3137ae8cab1