### PR TITLE
Relocate engine status and show game info in controls

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -142,27 +142,7 @@
     button:hover{ background:#5b97f0; }
     button:active{ transform:translateY(1px); }
 
-    /* Game info button + popover (App.js injects the button; styles here) */
-    .game-info-trigger{
-      position:absolute; top:12px; right:12px;
-      width:28px; height:28px;
-      display:flex; align-items:center; justify-content:center;
-      background:#0f141c; color:#cfe2ff;
-      border:1px solid #27405c; border-radius:999px;
-      font-weight:700; font-size:14px; line-height:1; cursor:pointer;
-    }
-    .game-info-trigger:hover{ background:#122032; }
-    .game-info-pop{
-      position:absolute; top:12px; right:12px; transform: translateY(36px);
-      width:min(90vw, 360px);
-      background:#0c1118; border:1px solid #1c2533; border-radius:12px; padding:10px;
-      box-shadow: 0 10px 24px rgba(0,0,0,.45);
-      z-index:40; display:none;
-    }
-    .game-info-pop.open{ display:block; }
-    .tip-row{ display:flex; gap:8px; margin:6px 0; align-items:flex-start }
-    .tip-label{ min-width:82px; color:var(--muted) }
-    .tip-value{ flex:1 }
+    /* Game info text styling */
     .tip-moves{
       flex:1;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
@@ -235,11 +215,23 @@
           <div class="pv" id="pvBox"></div>
         </div>
         <div class="row">
-          <div id="engineStatus" class="muted">Engine: ready</div>
+          <label class="muted">Turn</label>
+          <span id="infoTurn">—</span>
+        </div>
+        <div class="row">
+          <label class="muted">Opening</label>
+          <span id="infoOpening">—</span>
+        </div>
+        <div class="row">
+          <label class="muted">Moves</label>
+          <div class="tip-moves" id="infoMoves">—</div>
         </div>
 
         <details id="advancedControls">
           <summary>Advanced</summary>
+          <div class="row">
+            <div id="engineStatus" class="muted">Engine: ready</div>
+          </div>
           <div class="row" id="knobsRow">
             <label class="muted">Elo</label>
             <input type="range" id="elo" min="1" max="100" step="1" value="100" />

--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -24,6 +24,9 @@ class App {
 
     this.pvBox = qs('#pvBox');
     this.engineStatus = qs('#engineStatus');
+    this.infoTurn = qs('#infoTurn');
+    this.infoOpening = qs('#infoOpening');
+    this.infoMoves = qs('#infoMoves');
 
     // Controls
     this.modeSel = qs('#mode');
@@ -94,9 +97,6 @@ class App {
       onStateChanged: () => { this.syncBoard(); this.refreshAll(); },
       onMove: (mv) => this.playMoveSound(mv)
     });
-
-    // Floating info popover
-    this.installGameInfoPopover();
 
     // --- REVIEW MODE state ---
     this.inReview = false;      // true when viewing a past position
@@ -520,49 +520,15 @@ class App {
 
   refreshAll(){
     this.updateStatusMinimal();
-    this.updateGameInfo();   // info popover content
+    this.updateGameInfo();
   }
 
   updateStatusMinimal(){
-    // Minimal status; detailed info is in popover.
-  }
-
-
-  // === Game Info Popover ===
-  installGameInfoPopover(){
-    const wrap = document.querySelector('.board-wrap');
-    if (!wrap) return;
-
-    // Trigger
-    this.infoBtn = document.createElement('button');
-    this.infoBtn.type = 'button';
-    this.infoBtn.className = 'game-info-trigger';
-    this.infoBtn.setAttribute('aria-label','Game info');
-    this.infoBtn.textContent = 'ⓘ';
-
-    // Popover
-    this.infoPop = document.createElement('div');
-    this.infoPop.className = 'game-info-pop';
-    this.infoPop.innerHTML = '<div class="tip-row"><span class="tip-label">Loading…</span></div>';
-
-    wrap.appendChild(this.infoBtn);
-    wrap.appendChild(this.infoPop);
-
-    // Behavior
-    this.infoBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.infoPop.classList.toggle('open');
-    });
-    document.addEventListener('click', (e) => {
-      if (!this.infoPop.classList.contains('open')) return;
-      if (e.target === this.infoBtn) return;
-      if (this.infoPop.contains(e.target)) return;
-      this.infoPop.classList.remove('open');
-    });
+    // Minimal status; detailed info is in the card.
   }
 
   updateGameInfo(){
-    if (!this.infoPop) return;
+    if (!this.infoTurn || !this.infoOpening || !this.infoMoves) return;
 
     // 1) Turn
     let turnSide;
@@ -580,20 +546,9 @@ class App {
     // 3) Moves (numbered, compact)
     const movesText = this.formatMoves(sanHist) || '—';
 
-    this.infoPop.innerHTML = `
-      <div class="tip-row">
-        <span class="tip-label">Turn</span>
-        <span class="tip-value">${turnSide}${this.inReview ? ' (review)' : ''}</span>
-      </div>
-      <div class="tip-row">
-        <span class="tip-label">Opening</span>
-        <span class="tip-value">${openingName}</span>
-      </div>
-      <div class="tip-row">
-        <span class="tip-label">Moves</span>
-        <div class="tip-moves">${movesText}</div>
-      </div>
-    `;
+    this.infoTurn.textContent = turnSide + (this.inReview ? ' (review)' : '');
+    this.infoOpening.textContent = openingName;
+    this.infoMoves.textContent = movesText;
   }
 
   getSanHistory(){


### PR DESCRIPTION
## Summary
- Move engine status row into Advanced panel
- Replace removed engine status area with Turn, Opening, and Moves info
- Remove unused board tooltip popover and update logic to populate new fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e60bd6028832eab41f7a642b0b071