### PR TITLE
Swap clocks when board flips

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -39,6 +39,7 @@
 
     /* Board with clocks above and below */
     .board-area{display:flex; flex-direction:column; align-items:center; gap:8px}
+    .board-area.flipped{flex-direction:column-reverse}
 
     .board-wrap{
       position:relative; background:var(--layer);

--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -10,12 +10,13 @@ import { Sounds } from '../util/Sounds.js';
 
 const qs = (s) => document.querySelector(s);
 
-class App {
+export class App {
   constructor() {
     window.app = this;
 
     // DOM
     this.boardEl = qs('#board');
+    this.boardArea = qs('.board-area');
     this.arrowSvg = qs('#arrowSvg');
     this.evalbar = qs('#evalbar');
     this.evalWhite = qs('#evalWhite');
@@ -76,7 +77,7 @@ class App {
       getPieceAt: this.getPieceAt.bind(this),
       getLegalTargets: this.getLegalTargets.bind(this)
     });
-    this.ui.setOrientation(this.sideSel.value);
+    this.applyOrientation();
     this.updateSwitchButtonText();
 
     // Puzzles
@@ -169,7 +170,7 @@ class App {
     });
 
     this.sideSel.addEventListener('change', () => {
-      this.ui.setOrientation(this.sideSel.value);
+      this.applyOrientation();
       this.refreshAll();
       this.maybeEngineMove();
       this.updateSwitchButtonText();
@@ -181,7 +182,7 @@ class App {
         this.confirmRestart = false;
         this.switchBtn.classList.remove('confirm');
         this.sideSel.value = (this.sideSel.value === 'white') ? 'black' : 'white';
-        this.ui.setOrientation(this.sideSel.value);
+        this.applyOrientation();
         this.startNewGame();
         this.updateSwitchButtonText();
       } else {
@@ -233,6 +234,12 @@ class App {
         this.engineStatus.textContent = 'Invalid FEN';
       }
     });
+  }
+
+  applyOrientation(){
+    const side = this.sideSel.value;
+    this.ui.setOrientation(side);
+    this.boardArea.classList.toggle('flipped', side === 'black');
   }
 
   startNewGame(){
@@ -511,7 +518,7 @@ class App {
   }
 
   syncBoard(){
-    this.ui.setOrientation(this.sideSel.value);
+    this.applyOrientation();
     this.ui.setFen(this.getActiveFen());
     const ply = this.inReview ? this.reviewPly : this.getSanHistory().length;
     const inst = window.DrawOverlayInstance;

--- a/tests/clockSwap.test.js
+++ b/tests/clockSwap.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('applyOrientation flips clock container', async () => {
+  globalThis.document = {
+    getElementById() { return null; },
+    createElement() {
+      return { setAttribute() {}, appendChild() {}, style: {}, textContent: '', id: '' };
+    },
+    head: { appendChild() {} }
+  };
+  globalThis.window = { addEventListener() {} };
+  const { App } = await import('../chess-website-uml/public/src/app/App.js');
+
+  let oriented = null;
+  const app = Object.create(App.prototype);
+  app.ui = { setOrientation: (side) => { oriented = side; } };
+  app.sideSel = { value: 'white' };
+  const cls = {
+    _set: new Set(),
+    add(c){ this._set.add(c); },
+    remove(c){ this._set.delete(c); },
+    toggle(c, force){ force ? this.add(c) : this.remove(c); },
+    contains(c){ return this._set.has(c); }
+  };
+  app.boardArea = { classList: cls };
+
+  app.applyOrientation();
+  assert.equal(oriented, 'white');
+  assert.ok(!cls.contains('flipped'));
+
+  app.sideSel.value = 'black';
+  app.applyOrientation();
+  assert.equal(oriented, 'black');
+  assert.ok(cls.contains('flipped'));
+});
+


### PR DESCRIPTION
## Summary
- Flip clock positions by toggling `.board-area.flipped` when viewing from black's perspective
- Centralize orientation handling in `App` via new `applyOrientation` method
- Test clock container swapping on orientation change

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e61c1abe4832e9da9dbc962ea5365