### PR TITLE
feat: add pre-move support

### DIFF
--- a/tests/premove.test.js
+++ b/tests/premove.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Game } from '../chess-website-uml/public/src/core/Game.js';
+
+test('queued pre-move executes after opponent move', async () => {
+  globalThis.document = {
+    getElementById() { return null; },
+    createElement() {
+      return { setAttribute() {}, appendChild() {}, style: {}, textContent: '', id: '' };
+    },
+    head: { appendChild() {} },
+    querySelector() { return null; }
+  };
+  globalThis.window = { addEventListener() {}, dispatchEvent() {} };
+  const { App } = await import('../chess-website-uml/public/src/app/App.js');
+  const app = Object.create(App.prototype);
+  app.game = new Game();
+  app.modeSel = { value: 'play' };
+  app.sideSel = { value: 'white' };
+  app.inReview = false;
+  app.gameOver = false;
+  app.preMove = null;
+  app.clock = { onMoveApplied() {}, turn: 'w', white: 0, black: 0, inc: 0 };
+  app.clockPanel = { startIfNotRunning() {} };
+  app.ui = { clearArrow() {} };
+  app.playMoveSound = () => {};
+  app.syncBoard = () => {};
+  app.refreshAll = () => {};
+  app.maybeCelebrate = () => {};
+  app.checkGameOver = () => {};
+  app.requestAnalysis = () => {};
+  app.maybeEngineMove = () => {};
+  app.applyPreMove = App.prototype.applyPreMove.bind(app);
+  app.onUserMove = App.prototype.onUserMove.bind(app);
+
+  app.game.load('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1');
+
+  const ok = app.onUserMove({ from: 'e2', to: 'e4' });
+  assert.equal(ok, true);
+  assert.deepEqual(app.preMove, { from: 'e2', to: 'e4', promotion: 'q' });
+  assert.equal(app.game.get('e2').type, 'p');
+  assert.equal(app.game.turn(), 'b');
+
+  app.game.moveUci('e7e5');
+  app.applyPreMove();
+
+  assert.equal(app.preMove, null);
+  const piece = app.game.get('e4');
+  assert.equal(piece.color, 'w');
+  assert.equal(app.game.get('e2'), null);
+  assert.equal(app.game.turn(), 'b');
+});


### PR DESCRIPTION
## Summary
- allow queuing a move when it's not the player's turn
- automatically play a queued pre-move after the opponent moves
- test pre-move execution

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6334408c832eb027735585a2ea7f