### PR TITLE
Enable premove piece selection

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -348,24 +348,24 @@ export class App {
 
   getPieceAt(sq){
     const p = this.game.get(sq);
-    const turn = this.game.turn();
     if (this.modeSel.value === 'play'){
       const human = (this.sideSel.value === 'white') ? 'w' : 'b';
-      if (turn !== human || !p || p.color !== human) return null;
+      if (!p || p.color !== human) return null;
       return p;
     }
+    const turn = this.game.turn();
     if (!p || p.color !== turn) return null;
     return p;
   }
 
   getLegalTargets(sq){
     const p = this.game.get(sq);
-    const turn = this.game.turn();
     if (this.modeSel.value === 'play'){
       const human = (this.sideSel.value === 'white') ? 'w' : 'b';
-      if (turn !== human || !p || p.color !== human) return [];
-      return this.game.legalMovesFrom(sq);
+      if (!p || p.color !== human) return [];
+      return this.game.legalMovesFrom(sq, human);
     }
+    const turn = this.game.turn();
     if (!p || p.color !== turn) return [];
     return this.game.legalMovesFrom(sq);
   }

--- a/chess-website-uml/public/src/core/Game.js
+++ b/chess-website-uml/public/src/core/Game.js
@@ -20,9 +20,15 @@ export class Game {
 
   get(square){ return this.ch.get(square) || null; }
 
-  legalMovesFrom(square){
+  legalMovesFrom(square, color = null){
     try{
-      return this.ch.moves({ square, verbose:true }).map(m => m.to);
+      if (!color || color === this.ch.turn()){
+        return this.ch.moves({ square, verbose:true }).map(m => m.to);
+      }
+      const parts = this.ch.fen().split(' ');
+      parts[1] = color;
+      const temp = new Chess(parts.join(' '));
+      return temp.moves({ square, verbose:true }).map(m => m.to);
     }catch{ return []; }
   }
 

--- a/tests/premove.test.js
+++ b/tests/premove.test.js
@@ -32,8 +32,15 @@ test('queued pre-move executes after opponent move', async () => {
   app.maybeEngineMove = () => {};
   app.applyPreMove = App.prototype.applyPreMove.bind(app);
   app.onUserMove = App.prototype.onUserMove.bind(app);
+  app.getPieceAt = App.prototype.getPieceAt.bind(app);
+  app.getLegalTargets = App.prototype.getLegalTargets.bind(app);
 
   app.game.load('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1');
+
+  const startPiece = app.getPieceAt('e2');
+  assert.equal(startPiece?.type, 'p');
+  const targets = app.getLegalTargets('e2').sort();
+  assert.deepEqual(targets, ['e3', 'e4']);
 
   const ok = app.onUserMove({ from: 'e2', to: 'e4' });
   assert.equal(ok, true);


### PR DESCRIPTION
## Summary
- Allow legal move generation for either side, enabling premoves
- Permit selecting and inspecting your pieces when it's not your turn
- Add test covering piece selection and move generation during premove

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e665ad61c832e95c691cf9a65d146