### PR TITLE
Add premove highlight and cancellation

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -75,7 +75,8 @@ export class App {
       evalbar: { root: this.evalbar, white: this.evalWhite, black: this.evalBlack },
       onUserMove: this.onUserMove.bind(this),
       getPieceAt: this.getPieceAt.bind(this),
-      getLegalTargets: this.getLegalTargets.bind(this)
+      getLegalTargets: this.getLegalTargets.bind(this),
+      cancelPreMove: this.cancelPreMove.bind(this)
     });
     this.applyOrientation();
     this.updateSwitchButtonText();
@@ -247,7 +248,7 @@ export class App {
     this.exitReview();
     this.lastCelebrationPly = -1;
     this.gameOver = false;
-    this.preMove = null;
+    this.cancelPreMove();
     this.game.reset();
     this.ui.stopCelebration?.();
     this.ui.clearUserArrows?.();
@@ -382,6 +383,7 @@ export class App {
       const human = (this.sideSel.value === 'white') ? 'w' : 'b';
       if (this.game.turn() !== human){
         this.preMove = { from, to, promotion: promotion || 'q' };
+        this.ui.markPreMove?.(from, to);
         return true;
       }
     }
@@ -413,7 +415,15 @@ export class App {
     const mv = this.preMove;
     this.preMove = null;
     this.ui.clearArrow?.();
+    this.ui.clearPreMove?.();
     this.onUserMove(mv);
+  }
+
+  cancelPreMove(){
+    if (!this.preMove) return false;
+    this.preMove = null;
+    this.ui.clearPreMove?.();
+    return true;
   }
 
   maybeEngineMove(){

--- a/tests/premove.test.js
+++ b/tests/premove.test.js
@@ -57,3 +57,76 @@ test('queued pre-move executes after opponent move', async () => {
   assert.equal(app.game.get('e2'), null);
   assert.equal(app.game.turn(), 'b');
 });
+
+test('queued pre-move can be canceled', async () => {
+  globalThis.document = {
+    getElementById() { return null; },
+    createElement() {
+      return { setAttribute() {}, appendChild() {}, style: {}, textContent: '', id: '' };
+    },
+    head: { appendChild() {} },
+    querySelector() { return null; }
+  };
+  globalThis.window = { addEventListener() {}, dispatchEvent() {} };
+  const { App } = await import('../chess-website-uml/public/src/app/App.js');
+  const app = Object.create(App.prototype);
+  app.game = new Game();
+  app.modeSel = { value: 'play' };
+  app.sideSel = { value: 'white' };
+  app.inReview = false;
+  app.gameOver = false;
+  app.preMove = null;
+  app.clock = { onMoveApplied() {}, turn: 'w', white: 0, black: 0, inc: 0 };
+  app.clockPanel = { startIfNotRunning() {} };
+  app.ui = { clearArrow() {} };
+  app.onUserMove = App.prototype.onUserMove.bind(app);
+  app.cancelPreMove = App.prototype.cancelPreMove.bind(app);
+  app.getPieceAt = App.prototype.getPieceAt.bind(app);
+  app.getLegalTargets = App.prototype.getLegalTargets.bind(app);
+
+  app.game.load('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1');
+
+  const ok = app.onUserMove({ from: 'e2', to: 'e4' });
+  assert.equal(ok, true);
+  assert.notEqual(app.preMove, null);
+
+  const canceled = app.cancelPreMove();
+  assert.equal(canceled, true);
+  assert.equal(app.preMove, null);
+});
+
+test('recently queued pre-move survives click from drop', async () => {
+  globalThis.document = {
+    getElementById() { return null; },
+    createElement() { return { setAttribute() {}, appendChild() {}, style: {}, id: '', textContent: '' }; },
+    head: { appendChild() {} }
+  };
+  globalThis.window = { addEventListener() {}, removeEventListener() {} };
+  const { BoardUI } = await import('../chess-website-uml/public/src/ui/BoardUI.js');
+  let canceled = false;
+  const boardEl = {
+    _handler: null,
+    addEventListener(type, fn) {
+      if (type === 'click') this._handler = fn;
+    },
+  };
+  const ui = Object.create(BoardUI.prototype);
+  ui.boardEl = boardEl;
+  ui.cancelPreMove = () => { canceled = true; return true; };
+  ui.getPieceAt = () => null;
+  ui.getLegalTargets = () => [];
+  ui.selected = null;
+  ui.dragTargets = new Set();
+  ui.squareEl = () => ({ classList: { add(){}, remove(){} } });
+  ui.clearSelectionDots = () => {};
+  ui.markSelected = () => {};
+  BoardUI.prototype.attachClick.call(ui);
+
+  ui._preJustQueued = performance.now();
+  boardEl._handler({ target: {} });
+  assert.equal(canceled, false);
+
+  await new Promise(r => setTimeout(r, 120));
+  boardEl._handler({ target: { closest(){ return null; } } });
+  assert.equal(canceled, true);
+});


### PR DESCRIPTION
## Summary
- Show queued premoves with purple source/destination highlights
- Cancel a queued premove by clicking anywhere on the board
- Avoid canceling freshly queued premoves due to drop-generated clicks
- Test that queued premoves remain after drop and can still be canceled later

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e683e8770832e9e50ae97960931ab