### PR TITLE
Allow premoves capturing own piece

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -363,6 +363,9 @@ export class App {
     if (this.modeSel.value === 'play'){
       const human = (this.sideSel.value === 'white') ? 'w' : 'b';
       if (!p || p.color !== human) return [];
+      if (this.game.turn() !== human){
+        return this.game.premoveLegalMovesFrom(sq, human);
+      }
       return this.game.legalMovesFrom(sq, human);
     }
     const turn = this.game.turn();

--- a/chess-website-uml/public/src/core/Game.js
+++ b/chess-website-uml/public/src/core/Game.js
@@ -32,6 +32,25 @@ export class Game {
     }catch{ return []; }
   }
 
+  premoveLegalMovesFrom(square, color){
+    const moves = new Set(this.legalMovesFrom(square, color));
+    if (!color || color === this.ch.turn()) return Array.from(moves);
+    const baseFenParts = this.ch.fen().split(' ');
+    baseFenParts[1] = color;
+    const baseFen = baseFenParts.join(' ');
+    for (const row of this.ch.board()){
+      for (const piece of row){
+        if (piece && piece.color === color && piece.square !== square){
+          const temp = new Chess(baseFen);
+          temp.remove(piece.square);
+          const mvs = temp.moves({ square, verbose: true }).map(m => m.to);
+          if (mvs.includes(piece.square)) moves.add(piece.square);
+        }
+      }
+    }
+    return Array.from(moves);
+  }
+
   move(obj){ const m = this.ch.move(obj); if (m) this.redo.length = 0; return m; }
   moveUci(uci){
     const m = uci.match(/^([a-h][1-8])([a-h][1-8])([qrbn])?$/); if (!m) return null;

--- a/tests/premove.test.js
+++ b/tests/premove.test.js
@@ -57,3 +57,56 @@ test('queued pre-move executes after opponent move', async () => {
   assert.equal(app.game.get('e2'), null);
   assert.equal(app.game.turn(), 'b');
 });
+
+test('queued pre-move can target own piece square for recapture', async () => {
+  globalThis.document = {
+    getElementById() { return null; },
+    createElement() {
+      return { setAttribute() {}, appendChild() {}, style: {}, textContent: '', id: '' };
+    },
+    head: { appendChild() {} },
+    querySelector() { return null; }
+  };
+  globalThis.window = { addEventListener() {}, dispatchEvent() {} };
+  const { App } = await import('../chess-website-uml/public/src/app/App.js');
+  const app = Object.create(App.prototype);
+  app.game = new Game();
+  app.modeSel = { value: 'play' };
+  app.sideSel = { value: 'white' };
+  app.inReview = false;
+  app.gameOver = false;
+  app.preMove = null;
+  app.clock = { onMoveApplied() {}, turn: 'w', white: 0, black: 0, inc: 0 };
+  app.clockPanel = { startIfNotRunning() {} };
+  app.ui = { clearArrow() {} };
+  app.playMoveSound = () => {};
+  app.syncBoard = () => {};
+  app.refreshAll = () => {};
+  app.maybeCelebrate = () => {};
+  app.checkGameOver = () => {};
+  app.requestAnalysis = () => {};
+  app.maybeEngineMove = () => {};
+  app.applyPreMove = App.prototype.applyPreMove.bind(app);
+  app.onUserMove = App.prototype.onUserMove.bind(app);
+  app.getPieceAt = App.prototype.getPieceAt.bind(app);
+  app.getLegalTargets = App.prototype.getLegalTargets.bind(app);
+
+  app.game.load('4k3/8/8/4p3/3P4/2Q5/8/4K3 b - - 0 1');
+
+  const targets = app.getLegalTargets('c3').sort();
+  assert.ok(targets.includes('d4'));
+
+  const ok = app.onUserMove({ from: 'c3', to: 'd4' });
+  assert.equal(ok, true);
+  assert.deepEqual(app.preMove, { from: 'c3', to: 'd4', promotion: 'q' });
+  assert.equal(app.game.get('c3').type, 'q');
+
+  app.game.moveUci('e5d4');
+  app.applyPreMove();
+
+  assert.equal(app.preMove, null);
+  const piece = app.game.get('d4');
+  assert.equal(piece?.color, 'w');
+  assert.equal(piece?.type, 'q');
+  assert.equal(app.game.get('c3'), null);
+});


### PR DESCRIPTION
## Summary
- Handle self-capture premoves in `Game` with `premoveLegalMovesFrom`
- Use new helper to generate legal targets for queued recaptures

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6942e168832e84e4cad6d7e92e92