### PR TITLE
Amplify checkmate celebration with confetti and airhorn

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -372,8 +372,8 @@ export class App {
   }
 
   playMoveSound(mv){
-    if (this.isMateNow()) this.sounds.play('checkmate');
-    else if (this.isCheckNow()) this.sounds.play('check');
+    if (this.isMateNow()) return; // celebration handles the sound
+    if (this.isCheckNow()) this.sounds.play('check');
     else this.sounds.play(mv?.captured ? 'capture' : 'move');
   }
 
@@ -673,7 +673,23 @@ export class App {
     const ply = this.getSanHistory().length;
     if (this.isMateNow() && this.lastCelebrationPly !== ply){
       this.lastCelebrationPly = ply;
-      this.ui.celebrate?.();
+      let kingSq = null;
+      try {
+        const turn = this.game.turn();
+        const board = this.game.ch.board();
+        const files = 'abcdefgh';
+        outer: for (let r = 0; r < 8; r++) {
+          for (let f = 0; f < 8; f++) {
+            const piece = board[r][f];
+            if (piece && piece.type === 'k' && piece.color === turn) {
+              kingSq = files[f] + (8 - r);
+              break outer;
+            }
+          }
+        }
+      } catch {}
+      this.sounds.play('airhorn');
+      this.ui.celebrate?.(kingSq);
     }
   }
 }

--- a/chess-website-uml/public/src/ui/BoardUI.js
+++ b/chess-website-uml/public/src/ui/BoardUI.js
@@ -91,13 +91,13 @@ const BLACK_GLYPH = { k:'♚', q:'♛', r:'♜', b:'♝', n:'♞', p:'♟' };
     .confetti-root { position:absolute; inset:0; overflow:visible; pointer-events:none; z-index:5; }
     .confetti-piece {
       position:absolute;
-      top:-10px;
       width:8px; height:8px;
-      opacity:.9;
-      animation: confetti-fall 1.6s ease-out forwards;
+      opacity:.95;
+      transform: translate(-50%, -50%);
+      animation: confetti-explode 1.2s ease-out forwards;
     }
-    @keyframes confetti-fall {
-      to { transform: translateY(110%); opacity:0; }
+    @keyframes confetti-explode {
+      to { transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))); opacity:0; }
     }
   `;
   document.head.appendChild(st);
@@ -754,7 +754,7 @@ export class BoardUI {
   }
 
   // -------- celebration --------
-  celebrate(){
+  celebrate(square){
     // remove any existing celebration
     this.stopCelebration();
 
@@ -762,18 +762,24 @@ export class BoardUI {
     root.className = 'confetti-root';
     this.boardEl.appendChild(root);
 
+    const origin = square ? this.squareCenterPx(square) : { x: this.boardEl.clientWidth / 2, y: this.boardEl.clientHeight / 2 };
     const colors = ['#e74c3c', '#f1c40f', '#2ecc71', '#3498db', '#9b59b6'];
-    for (let i = 0; i < 40; i++){
+    for (let i = 0; i < 120; i++){
       const piece = document.createElement('div');
       piece.className = 'confetti-piece';
-      piece.style.left = Math.random() * 100 + '%';
+      piece.style.left = `${origin.x}px`;
+      piece.style.top = `${origin.y}px`;
       piece.style.backgroundColor = colors[Math.floor(Math.random()*colors.length)];
-      piece.style.animationDelay = (Math.random() * 0.7).toFixed(2) + 's';
+      const angle = Math.random() * Math.PI * 2;
+      const distance = 80 + Math.random() * 120;
+      piece.style.setProperty('--dx', `${Math.cos(angle) * distance}px`);
+      piece.style.setProperty('--dy', `${Math.sin(angle) * distance}px`);
+      piece.style.animationDelay = (Math.random() * 0.2).toFixed(2) + 's';
       root.appendChild(piece);
     }
 
     this._celebrationRoot = root;
-    this._celebrationTimer = setTimeout(()=>this.stopCelebration(), 1600);
+    this._celebrationTimer = setTimeout(()=>this.stopCelebration(), 1500);
   }
 
   stopCelebration(){

--- a/chess-website-uml/public/src/util/Sounds.js
+++ b/chess-website-uml/public/src/util/Sounds.js
@@ -11,10 +11,20 @@ export class Sounds {
       // slight variation each play
       const detune = 1 + (Math.random() - 0.5) * 0.1; // ±5%
 
+      const profiles = {
+        move: { filter: 1500, osc: 200, dur: 0.2 },
+        capture: { filter: 1000, osc: 160, dur: 0.2 },
+        check: { filter: 1700, osc: 400, dur: 0.25 },
+        checkmate: { filter: 1800, osc: 600, dur: 0.3 },
+        airhorn: { filter: 800, osc: 150, dur: 1.2, gain: 0.25, type: 'square' }
+      };
+      const p = profiles[name] || profiles.move;
+
       const gain = ctx.createGain();
+      const maxGain = p.gain ?? 0.09;
       gain.gain.setValueAtTime(0, now);
-      gain.gain.linearRampToValueAtTime(0.09, now + 0.01);
-      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
+      gain.gain.linearRampToValueAtTime(maxGain, now + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + p.dur);
 
       // soft noise burst to mimic cushioned piece drop
       const noise = ctx.createBufferSource();
@@ -25,14 +35,6 @@ export class Sounds {
       }
       noise.buffer = buffer;
 
-      const profiles = {
-        move: { filter: 1500, osc: 200, dur: 0.2 },
-        capture: { filter: 1000, osc: 160, dur: 0.2 },
-        check: { filter: 1700, osc: 400, dur: 0.25 },
-        checkmate: { filter: 1800, osc: 600, dur: 0.3 }
-      };
-      const p = profiles[name] || profiles.move;
-
       const filter = ctx.createBiquadFilter();
       filter.type = 'lowpass';
       filter.frequency.value = p.filter * detune;
@@ -40,9 +42,9 @@ export class Sounds {
       noise.connect(filter);
       filter.connect(gain);
 
-      // subtle tone
+      // subtle tone or horn
       const osc = ctx.createOscillator();
-      osc.type = 'sine';
+      osc.type = p.type || 'sine';
       osc.frequency.value = p.osc * detune;
       osc.connect(gain);
 


### PR DESCRIPTION
## Summary
- Create an airhorn sound profile and use it when a mate occurs
- Trigger celebration from the checkmated king's square with a large confetti blast
- Skip regular checkmate sound so the airhorn handles victory audio

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6e8eae8c832ea3a8a54289f991f7