### PR TITLE
Fix puzzle adaptation and theme handling

### DIFF
--- a/chess-website-uml/public/src/puzzles/PuzzleModel.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleModel.js
@@ -23,18 +23,10 @@ export function adaptLichessPuzzle(input){
 
   if (!fen || !uciList.length) throw new Error('Puzzle missing FEN or moves');
 
-  // Convert UCI -> SAN (after first move)
+  // Convert UCI -> SAN for the entire solution sequence.
   const tmp = new Chess(fen);
-  // Lichess puzzles: show position AFTER the first solution move.
-  const first = uciList[0];
-  const m0 = first.match(/^([a-h][1-8])([a-h][1-8])([qrbn])?$/);
-  if (!m0 || !tmp.move({ from: m0[1], to: m0[2], promotion: m0[3] || undefined })) {
-    throw new Error('Invalid first move vs FEN');
-  }
-  const startFen = tmp.fen();
-
   const solutionSan = [];
-  for (let i = 1; i < uciList.length; i++) {
+  for (let i = 0; i < uciList.length; i++) {
     const m = uciList[i].match(/^([a-h][1-8])([a-h][1-8])([qrbn])?$/);
     if (!m) break;
     const step = tmp.move({ from: m[1], to: m[2], promotion: m[3] || undefined });
@@ -44,7 +36,7 @@ export function adaptLichessPuzzle(input){
 
   return {
     id: id || 'Lichess',
-    fen: startFen,
+    fen,
     solutionSan,
     rating: rating || 0,
     themes: Array.isArray(themes) ? themes.join(',') : (themes || ''),

--- a/chess-website-uml/public/src/puzzles/PuzzleUI.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleUI.js
@@ -92,7 +92,7 @@ export class PuzzleUI {
 
   loadBuiltinRandom(){
     const p = BUILTIN_PUZZLES[Math.floor(Math.random()*BUILTIN_PUZZLES.length)];
-    this.current = { id:p.id, thema:p.thema, fen:p.fen, solutionSan: p.solution.slice() };
+    this.current = { id:p.id, themes:p.themes, fen:p.fen, solutionSan: p.solution.slice() };
     this.index = 0;
     this.applyCurrent(true);
   }
@@ -117,8 +117,8 @@ export class PuzzleUI {
 
     // show puzzle meta
     if (this.dom?.puzzleInfo){
-      const tag = this.current.thema ? ` — <span class="muted">${this.current.thema}</span>` : '';
-      this.dom.puzzleInfo.innerHTML = `<b>Puzzle</b> #${this.current.id || 'local'}${tag}`;
+      const themeText = this.current.themes ? ` — <span class="muted">${this.current.themes}</span>` : '';
+      this.dom.puzzleInfo.innerHTML = `<b>Puzzle</b> #${this.current.id || 'local'}${themeText}`;
     }
     if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent = '';
 
@@ -180,19 +180,19 @@ async function adaptOrIdentity(p){
     if (p && (p.id || p.PuzzleId)) return adaptLichessPuzzle(p);
   }catch{}
   // fallback: expect { id, fen, solution: [SAN...] }
-  return { id: p.id||'local', fen: p.fen, thema: p.thema||'', solutionSan: (p.solution||[]).slice() };
+  return { id: p.id||'local', fen: p.fen, themes: p.themes || p.thema || '', solutionSan: (p.solution||[]).slice() };
 }
 
 // Tiny demo pack to prime the UI if users don’t provide one
 const DEMO_PACK = [
-  { id:'demo-1', fen:'r2q1rk1/pp1b1ppp/2n1pn2/2bp4/3P4/2PBPN2/PP3PPP/R1BQ1RK1 w - - 0 1', thema:'QGD', solution:['dxc5','e5','e4'] },
-  { id:'demo-2', fen:'rnbqk2r/pppp1ppp/5n2/4p3/1bP5/2N2N2/PP1PPPPP/R1BQKB1R w KQkq - 2 4', thema:'Sicilian/Caro', solution:['Nxe5','O-O','g3'] },
-  { id:'demo-3', fen:'r2q1rk1/pp2bppp/2n1pn2/2bp4/3P4/2P1PN2/PP1N1PPP/R1BQ1RK1 w - - 0 1', thema:'QGD', solution:['dxc5','e5','e4'] },
+  { id:'demo-1', fen:'r2q1rk1/pp1b1ppp/2n1pn2/2bp4/3P4/2PBPN2/PP3PPP/R1BQ1RK1 w - - 0 1', themes:'QGD', solution:['dxc5','e5','e4'] },
+  { id:'demo-2', fen:'rnbqk2r/pppp1ppp/5n2/4p3/1bP5/2N2N2/PP1PPPPP/R1BQKB1R w KQkq - 2 4', themes:'Sicilian/Caro', solution:['Nxe5','O-O','g3'] },
+  { id:'demo-3', fen:'r2q1rk1/pp2bppp/2n1pn2/2bp4/3P4/2P1PN2/PP1N1PPP/R1BQ1RK1 w - - 0 1', themes:'QGD', solution:['dxc5','e5','e4'] },
 ];
 
 // A few built-in puzzles if there’s nothing else around
 const BUILTIN_PUZZLES = [
-  { id:'b1', thema:'Mate in 1', fen:'6k1/5ppp/8/8/8/8/5PPP/6KQ w - - 0 1', solution:['Qa8#'] },
-  { id:'b2', thema:'Fork', fen:'r1bqkbnr/pppp1ppp/2n5/4p3/3P4/5N2/PPP1PPPP/RNBQKB1R w KQkq - 2 3', solution:['d5','Nd4'] },
-  { id:'b3', thema:'Skewer', fen:'3r2k1/pp3ppp/8/8/8/8/PP3PPP/3R2K1 w - - 0 1', solution:['Rxd8#'] },
+  { id:'b1', themes:'Mate in 1', fen:'6k1/5ppp/8/8/8/8/5PPP/6KQ w - - 0 1', solution:['Qa8#'] },
+  { id:'b2', themes:'Fork', fen:'r1bqkbnr/pppp1ppp/2n5/4p3/3P4/5N2/PPP1PPPP/RNBQKB1R w KQkq - 2 3', solution:['d5','Nd4'] },
+  { id:'b3', themes:'Skewer', fen:'3r2k1/pp3ppp/8/8/8/8/PP3PPP/3R2K1 w - - 0 1', solution:['Rxd8#'] },
 ];

--- a/tests/puzzleModel.test.js
+++ b/tests/puzzleModel.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { adaptLichessPuzzle } from '../chess-website-uml/public/src/puzzles/PuzzleModel.js';
+
+// Sample puzzle shaped like Lichess API response
+const SAMPLE = {
+  puzzle: {
+    id: 'p123',
+    fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2',
+    rating: 1500,
+    themes: ['fork'],
+    solution: ['d7d5', 'e4d5', 'd8d5', 'b1c3']
+  },
+  game: { id: 'ABCDEFG' }
+};
+
+const EXPECTED_SAN = ['d5', 'exd5', 'Qxd5', 'Nc3'];
+
+test('adaptLichessPuzzle keeps initial FEN and full solution', () => {
+  const res = adaptLichessPuzzle(SAMPLE);
+  assert.equal(res.fen, SAMPLE.puzzle.fen);
+  assert.deepEqual(res.solutionSan, EXPECTED_SAN);
+});


### PR DESCRIPTION
## Summary
- Convert full UCI move list to SAN and preserve original FEN when adapting puzzles
- Unify puzzle theme naming and display in UI
- Add regression test for puzzle adaptation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e75e46910832ea8a9a62531ce8354