### PR TITLE
Handle invalid FEN in complexity estimate

### DIFF
--- a/chess-website-uml/public/src/engine/TimeManager.js
+++ b/chess-website-uml/public/src/engine/TimeManager.js
@@ -1,8 +1,13 @@
 import { Chess } from "../vendor/chess.mjs";
 
 export function estimateComplexity(fen) {
-  const ch = new Chess(fen);
-  const moves = ch.moves({ verbose: true });
+  let moves = [];
+  try {
+    const ch = new Chess(fen);
+    moves = ch.moves({ verbose: true });
+  } catch {
+    return 0;
+  }
   let complexity = moves.length;
   let tactical = 0;
   for (const mv of moves) {

--- a/tests/timeManager.test.js
+++ b/tests/timeManager.test.js
@@ -34,3 +34,7 @@ test("panic mode limits time usage when very low on clock", () => {
   });
   assert.ok(t <= 250);
 });
+
+test("estimateComplexity handles invalid FEN", () => {
+  assert.equal(estimateComplexity("invalid fen"), 0);
+});


### PR DESCRIPTION
## Summary
- prevent `estimateComplexity` from throwing on bad FEN strings
- add regression test for invalid FEN handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e75ede834832e80df6d659efa2bf4