### PR TITLE
Fix adaptOrIdentity for Lichess daily puzzles

### DIFF
--- a/chess-website-uml/public/src/puzzles/PuzzleUI.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleUI.js
@@ -175,9 +175,9 @@ export class PuzzleUI {
 }
 
 // Prefer native lichess format, else pass-through
-async function adaptOrIdentity(p){
+export async function adaptOrIdentity(p){
   try{
-    if (p && (p.id || p.PuzzleId)) return adaptLichessPuzzle(p);
+    if (p && (p.puzzle || p.id || p.PuzzleId)) return adaptLichessPuzzle(p);
   }catch{}
   // fallback: expect { id, fen, solution: [SAN...] }
   return { id: p.id||'local', fen: p.fen, themes: p.themes || p.thema || '', solutionSan: (p.solution||[]).slice() };

--- a/tests/adaptOrIdentity.test.js
+++ b/tests/adaptOrIdentity.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { adaptOrIdentity } from '../chess-website-uml/public/src/puzzles/PuzzleUI.js';
+
+const SAMPLE = {
+  puzzle: {
+    id: 'p123',
+    fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2',
+    rating: 1500,
+    themes: ['fork'],
+    solution: ['d7d5', 'e4d5', 'd8d5', 'b1c3']
+  },
+  game: { id: 'ABCDEFG' }
+};
+
+const EXPECTED_SAN = ['d5', 'exd5', 'Qxd5', 'Nc3'];
+
+test('adaptOrIdentity adapts Lichess daily puzzle', async () => {
+  const res = await adaptOrIdentity(SAMPLE);
+  assert.equal(res.fen, SAMPLE.puzzle.fen);
+  assert.deepEqual(res.solutionSan, EXPECTED_SAN);
+});


### PR DESCRIPTION
## Summary
- Detect Lichess daily puzzle objects in `adaptOrIdentity` and export the helper
- Add unit test ensuring daily puzzle conversion works

## Testing
- `npm test`
- `npm run lint` (warnings: 6)


------
https://chatgpt.com/codex/tasks/task_e_68a07688b888832ea24c1360a4edc4ed