### PR TITLE
Fix daily puzzle loading and orientation

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -100,7 +100,11 @@ export class App {
         hintBtn: qs('#puzzleHint'), puzzleInfo: qs('#puzzleInfo'), puzzleStatus: qs('#puzzleStatus')
       },
       onStateChanged: () => { this.syncBoard(); this.refreshAll(); },
-      onMove: (mv) => this.playMoveSound(mv)
+      onMove: (mv) => this.playMoveSound(mv),
+      onPuzzleLoad: (turn) => {
+        this.sideSel.value = (turn === 'w') ? 'white' : 'black';
+        this.updateSwitchButtonText();
+      }
     });
 
     // --- REVIEW MODE state ---

--- a/chess-website-uml/public/src/puzzles/PuzzleModel.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleModel.js
@@ -1,8 +1,8 @@
 import { Chess } from '../vendor/chess.mjs';
 
 // Accepts various shapes:
-// - Lichess daily/byId: { puzzle:{ id, fen, solution:[uci...], rating, themes, gameId? }, game:{ id? } }
-// - Our CSV/JSON:       { id, fen, moves:"uci uci ...", rating, themes, gameUrl }
+// - Lichess daily/byId: { puzzle:{ id, fen, solution:[uci...]|"uci...", moves:[uci...]|"uci...", rating, themes, gameId? }, game:{ id? } }
+// - Our CSV/JSON:       { id, fen, solution:[uci...]|"uci...", moves:[uci...]|"uci...", rating, themes, gameUrl }
 // - Already adapted:    { id, fen, solutionSan:[...], ... }
 export function adaptLichessPuzzle(input){
   // Already adapted?
@@ -51,17 +51,23 @@ function normaliseToFenAndUci(src){
   if (src.puzzle) {
     const p = src.puzzle || {};
     const g = src.game || {};
-    const fen = p.fen || src.fen || '';
-    const uciList = Array.isArray(p.solution) ? p.solution.slice()
-                  : typeof p.moves === 'string' ? p.moves.trim().split(/\s+/) : [];
+    // Some endpoints nest the FEN under game
+    const fen = p.fen || g.fen || src.fen || '';
+    const uciList =
+      Array.isArray(p.solution) ? p.solution.slice() :
+      typeof p.solution === 'string' ? p.solution.trim().split(/\s+/) :
+      Array.isArray(p.moves) ? p.moves.slice() :
+      typeof p.moves === 'string' ? p.moves.trim().split(/\s+/) : [];
     const gameUrl = g.id ? `https://lichess.org/${g.id}` : (src.gameUrl || '');
     return { id: p.id, fen, uciList, rating: p.rating, themes: p.themes, gameUrl };
   }
 
   // Our CSV/JSON shape
-  const fen = src.fen || '';
+  const fen = src.fen || src.game?.fen || '';
   const uciList =
     Array.isArray(src.solution) ? src.solution.slice() :
+    typeof src.solution === 'string' ? src.solution.trim().split(/\s+/) :
+    Array.isArray(src.moves) ? src.moves.slice() :
     typeof src.moves === 'string' ? src.moves.trim().split(/\s+/) : [];
   return { id: src.id, fen, uciList, rating: src.rating, themes: src.themes, gameUrl: src.gameUrl };
 }

--- a/chess-website-uml/public/src/puzzles/PuzzleUI.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleUI.js
@@ -5,13 +5,14 @@ import { adaptLichessPuzzle } from './PuzzleModel.js';
 function on(el, type, fn){ if (el) el.addEventListener(type, fn); }
 
 export class PuzzleUI {
-  constructor({ game, ui, service, dom, onStateChanged, onMove }) {
+  constructor({ game, ui, service, dom, onStateChanged, onMove, onPuzzleLoad }) {
     this.game = game;
     this.ui = ui;
     this.svc = service;
     this.dom = dom || {};
     this.onStateChanged = onStateChanged || (()=>{});
     this.onMove = onMove || (()=>{});
+    this.onPuzzleLoad = onPuzzleLoad || (()=>{});
 
     this.current = null;
     this.index = 0;
@@ -122,6 +123,7 @@ export class PuzzleUI {
     }
     if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent = '';
 
+    this.onPuzzleLoad(this.game.turn?.());
     this.onStateChanged();
     if (center && this.ui?.resizeOverlay) this.ui.resizeOverlay();
   }

--- a/tests/adaptOrIdentity.test.js
+++ b/tests/adaptOrIdentity.test.js
@@ -20,3 +20,38 @@ test('adaptOrIdentity adapts Lichess daily puzzle', async () => {
   assert.equal(res.fen, SAMPLE.puzzle.fen);
   assert.deepEqual(res.solutionSan, EXPECTED_SAN);
 });
+
+const SAMPLE_STR = {
+  puzzle: {
+    id: 'p124',
+    fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2',
+    rating: 1500,
+    themes: ['fork'],
+    solution: 'd7d5 e4d5 d8d5 b1c3'
+  }
+};
+
+test('adaptOrIdentity handles solution strings', async () => {
+  const res = await adaptOrIdentity(SAMPLE_STR);
+  assert.equal(res.fen, SAMPLE_STR.puzzle.fen);
+  assert.deepEqual(res.solutionSan, EXPECTED_SAN);
+});
+
+const SAMPLE_GAME_FEN = {
+  puzzle: {
+    id: 'p125',
+    rating: 1500,
+    themes: ['fork'],
+    solution: ['d7d5', 'e4d5']
+  },
+  game: {
+    id: 'HIJKLMN',
+    fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
+  }
+};
+
+test('adaptOrIdentity uses game FEN when puzzle FEN missing', async () => {
+  const res = await adaptOrIdentity(SAMPLE_GAME_FEN);
+  assert.equal(res.fen, SAMPLE_GAME_FEN.game.fen);
+  assert.deepEqual(res.solutionSan, ['d5', 'exd5']);
+});

--- a/tests/puzzleOrientation.test.js
+++ b/tests/puzzleOrientation.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PuzzleUI } from '../chess-website-uml/public/src/puzzles/PuzzleUI.js';
+
+// Ensure puzzle loading orients board for side to move
+
+test('loadConvertedPuzzle flips orientation', async () => {
+  const game = {
+    fenStr: '',
+    load(f){ this.fenStr = f; },
+    fen(){ return this.fenStr; },
+    turn(){ return this.fenStr.split(' ')[1]; },
+    moveSan(){ return {}; },
+    undo(){}
+  };
+  let oriented = null;
+  const app = { sideSel: { value: 'white' } };
+  const ui = {
+    clearArrow() {},
+    resizeOverlay() {},
+    drawArrowUci() {},
+    setOrientation(side){ oriented = side; }
+  };
+  const puzzles = new PuzzleUI({
+    game,
+    ui,
+    service: {},
+    dom: {},
+    onStateChanged: () => ui.setOrientation(app.sideSel.value),
+    onMove: () => {},
+    onPuzzleLoad: (turn) => { app.sideSel.value = (turn === 'w') ? 'white' : 'black'; }
+  });
+
+  await puzzles.loadConvertedPuzzle({ puzzle:{ id:'p1', fen:'8/8/8/8/8/8/8/k6K b - - 0 1', moves:'a1b1' } });
+  assert.equal(app.sideSel.value, 'black');
+  assert.equal(oriented, 'black');
+});


### PR DESCRIPTION
## Summary
- handle string and array move formats when adapting puzzles
- orient board to side-to-move when loading puzzles
- read FEN from game object when puzzle FEN is missing
- cover puzzle parsing and orientation with new tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a07b3ea380832e96f10a34198d5535