### PR TITLE
Fix puzzle move validation to prevent board freeze

### DIFF
--- a/chess-website-uml/public/src/puzzles/PuzzleUI.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleUI.js
@@ -134,8 +134,7 @@ export class PuzzleUI {
     if (!sanNeeded) return false;
 
     // Compare user move with expected SAN
-    const tmp = new Chess(this.game.fen());
-    const userSan = tmp.move({ from: mv.from, to: mv.to, promotion: mv.promotion }).san;
+    const userSan = mv?.san;
     if (userSan === sanNeeded){
       // Good move
       this.index++;
@@ -146,10 +145,8 @@ export class PuzzleUI {
       } else {
         // Auto play the opponent reply (next SAN)
         const reply = this.current.solutionSan[this.index];
-        const tmp2 = new Chess(this.game.fen());
-        const rm = tmp2.move(reply);
-        if (rm){
-          const applied = this.game.moveSan(reply);
+        const applied = this.game.moveSan(reply);
+        if (applied){
           this.onMove(applied);
           this.index++;
           this.onStateChanged();

--- a/tests/puzzleValidation.test.js
+++ b/tests/puzzleValidation.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PuzzleUI } from '../chess-website-uml/public/src/puzzles/PuzzleUI.js';
+import { Game } from '../chess-website-uml/public/src/core/Game.js';
+
+const PUZZLE = {
+  id: 'test',
+  fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2',
+  solutionSan: ['d5', 'exd5']
+};
+
+function createPuzzleUI() {
+  const game = new Game();
+  const ui = { clearArrow() {}, drawArrowUci() {} };
+  const puzzles = new PuzzleUI({
+    game,
+    ui,
+    service: {},
+    dom: {},
+    onStateChanged: () => {},
+    onMove: () => {}
+  });
+  puzzles.current = { ...PUZZLE };
+  puzzles.index = 0;
+  puzzles.applyCurrent();
+  return { puzzles, game };
+}
+
+test('handleUserMove accepts correct moves and advances puzzle', () => {
+  const { puzzles, game } = createPuzzleUI();
+  const mv = game.move({ from: 'd7', to: 'd5' });
+  assert.ok(mv);
+  const res = puzzles.handleUserMove(mv);
+  assert.equal(res, true);
+  assert.equal(puzzles.index, 2); // both moves played
+});
+
+test('handleUserMove rejects incorrect moves and reverts position', () => {
+  const { puzzles, game } = createPuzzleUI();
+  const mv = game.move({ from: 'g8', to: 'f6' }); // Nf6 is wrong
+  assert.ok(mv);
+  const res = puzzles.handleUserMove(mv);
+  assert.equal(res, false);
+  assert.equal(puzzles.index, 0);
+  assert.equal(game.fen(), PUZZLE.fen);
+});


### PR DESCRIPTION
## Summary
- Avoid reapplying user moves when validating puzzles by using SAN from the move object
- Autoplay opponent replies directly and undo incorrect moves
- Add tests covering correct and incorrect puzzle moves

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a086364c24832eb4ca13241a57622c