### PR TITLE
Center card buttons and emphasize active mode

### DIFF
--- a/chess-website-uml/public/css/base.css
+++ b/chess-website-uml/public/css/base.css
@@ -30,6 +30,7 @@ header h1{font-size:28px;margin:0;text-align:center}
   backdrop-filter:blur(6px);
 }
 .row{display:flex; gap:12px; align-items:center; flex-wrap:wrap}
+.button-row{justify-content:center}
 
 button,
 select,
@@ -48,7 +49,7 @@ button:active{transform:scale(.97);}
 input::placeholder{color:var(--muted);}
 
 .btn{background:#1b2432;border:1px solid #2a3443;color:var(--text);padding:6px 10px;border-radius:8px;cursor:pointer}
-.btn.primary{background:linear-gradient(180deg,#2a76ff,#1b5fff);border-color:#2a6aff}
+.btn.primary{background:linear-gradient(180deg,#2a76ff,#1b5fff);border-color:#2a6aff;box-shadow:0 0 8px var(--accent);font-weight:bold}
 .muted{color:var(--muted)}
 .badge{font-size:12px;padding:2px 6px;border-radius:8px;background:#203452;border:1px solid #294561}
 

--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -122,6 +122,7 @@
     }
     .row{display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin:8px 0}
     .row label{min-width:80px}
+    .button-row{justify-content:center}
 
     /* Form controls */
     select,
@@ -170,6 +171,7 @@
     }
     button:hover{ background:#5b97f0; }
     button:active{ transform:scale(.97); box-shadow:0 1px 2px rgba(0,0,0,.25); }
+    button.primary{ box-shadow:0 0 8px var(--accent); font-weight:bold; }
 
     /* Game info text styling */
     .tip-moves{
@@ -223,7 +225,7 @@
 
       <!-- CONTROLS UNDER THE BOARD -->
       <div class="card">
-        <div class="row">
+        <div class="row button-row">
           <label for="side" style="display:none">Your side</label>
           <select id="side" style="display:none">
             <option value="white">White</option>
@@ -233,7 +235,7 @@
           <button id="switchSide" class="switch-btn">Switch to black and restart</button>
         </div>
 
-        <div class="row" id="modeButtons">
+        <div class="row button-row" id="modeButtons">
           <button class="btn" data-mode="play">Play vs Engine</button>
           <button class="btn" data-mode="analysis">Analysis</button>
           <button class="btn" data-mode="puzzle">Puzzles</button>


### PR DESCRIPTION
## Summary
- Centered card button rows for cleaner layout
- Added blue glow and bold text to the active mode button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0aa89a550832eb5e6c495acd90b3d