### PR TITLE
Add puzzle playlist filtering by opening

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -1,364 +1,701 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Chess by Sam</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#0f1216" />
-  <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+  <head>
+    <meta charset="utf-8" />
+    <title>Chess by Sam</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#0f1216" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
 
-  <style>
-    :root{
-      --bg:#0f1216; --layer:#141922; --muted:#8aa0b6; --text:#e8eef5;
-      --square-dark:#2a3443; --square-light:#3a475b; --hl:#6ba7ff;
-      --accent:#6ba7ff; --good:#39d98a; --bad:#ff6b6b;
-      --cell: 64px; --pieceSize: 52px;
-      --content-w: 92vw;
-    }
-    *{box-sizing:border-box}
-    html, body{height:100%}
-    body{
-      margin:0; background:var(--bg); color:var(--text);
-      font: 15px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial;
-    }
-    a{color:var(--accent); text-decoration:none} a:hover{text-decoration:underline}
-    .muted{color:var(--muted)}
-    .page{max-width:1400px; margin:0 auto; padding:16px}
+    <style>
+      :root {
+        --bg: #0f1216;
+        --layer: #141922;
+        --muted: #8aa0b6;
+        --text: #e8eef5;
+        --square-dark: #2a3443;
+        --square-light: #3a475b;
+        --hl: #6ba7ff;
+        --accent: #6ba7ff;
+        --good: #39d98a;
+        --bad: #ff6b6b;
+        --cell: 64px;
+        --pieceSize: 52px;
+        --content-w: 92vw;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font:
+          15px/1.4 system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Ubuntu,
+          Cantarell,
+          Noto Sans,
+          Helvetica Neue,
+          Arial;
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .muted {
+        color: var(--muted);
+      }
+      .page {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 16px;
+      }
 
-    header{display:flex; flex-direction:column; align-items:center; gap:6px; margin-bottom:12px}
-    header h1{position:relative; margin:4px 0 0 0; font-weight:800; letter-spacing:.2px; text-align:center}
-    header h1 .by-sam{position:absolute; left:100%; top:50%; transform:translateY(-50%); margin-left:8px; font-size:30%; color:var(--muted)}
+      header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 12px;
+      }
+      header h1 {
+        position: relative;
+        margin: 4px 0 0 0;
+        font-weight: 800;
+        letter-spacing: 0.2px;
+        text-align: center;
+      }
+      header h1 .by-sam {
+        position: absolute;
+        left: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        margin-left: 8px;
+        font-size: 30%;
+        color: var(--muted);
+      }
 
-    footer.site-footer{
-      margin-top:40px; padding-top:8px; border-top:1px solid #222a36;
-      text-align:center; font-size:13px; color:var(--muted);
-    }
-    footer.site-footer a{color:var(--accent)}
+      footer.site-footer {
+        margin-top: 40px;
+        padding-top: 8px;
+        border-top: 1px solid #222a36;
+        text-align: center;
+        font-size: 13px;
+        color: var(--muted);
+      }
+      footer.site-footer a {
+        color: var(--accent);
+      }
 
-    /* Board section first; controls below (single column) */
-    .stack{display:flex; flex-direction:column; gap:14px}
+      /* Board section first; controls below (single column) */
+      .stack {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+      }
 
-    /* Board with clocks above and below */
-    .board-area{display:flex; flex-direction:column; align-items:center; gap:8px}
-    .board-area.flipped{flex-direction:column-reverse}
+      /* Board with clocks above and below */
+      .board-area {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+      }
+      .board-area.flipped {
+        flex-direction: column-reverse;
+      }
 
-    .board-wrap{
-      position:relative; background:var(--layer);
-      border:1px solid #222a36; border-radius:12px; padding:10px;
-      margin-inline:auto; width:92vw; max-width:660px;
-    }
-    @media (min-width: 980px){
-      .board-wrap{ width:40vw; max-width:none; }
-    }
+      .board-wrap {
+        position: relative;
+        background: var(--layer);
+        border: 1px solid #222a36;
+        border-radius: 12px;
+        padding: 10px;
+        margin-inline: auto;
+        width: 92vw;
+        max-width: 660px;
+      }
+      @media (min-width: 980px) {
+        .board-wrap {
+          width: 40vw;
+          max-width: none;
+        }
+      }
 
-    /* Board */
-    #board{ position:relative;
-      width:100%; aspect-ratio:1/1; display:grid;
-      grid-template-columns:repeat(8, 1fr);
-      grid-template-rows:repeat(8, 1fr);
-      border-radius:12px; overflow:hidden; touch-action:none; cursor:grab; user-select:none;
-    }
-    .sq{position:relative; display:flex; align-items:center; justify-content:center; line-height:1; font-size:var(--pieceSize)}
-    .sq.light{background:var(--square-light)} .sq.dark{background:var(--square-dark)}
-    .sq.sel{outline:3px solid rgba(107,167,255,.95); outline-offset:-3px}
-    .sq.hover{box-shadow: inset 0 0 0 3px rgba(107,167,255,.95)}
-    .sq .dot{position:absolute; width:28%; height:28%; border-radius:50%; background:rgba(255,255,255,0.35)}
-    .sq.cap::after{content:""; position:absolute; inset:10%; border:3px solid rgba(255,255,255,.55); border-radius:50%}
-    .sq.dragSource{opacity:.25}
-    @keyframes shake{0%{transform:translateX(0)}25%{transform:translateX(-3px)}50%{transform:translateX(3px)}75%{transform:translateX(-3px)}100%{transform:translateX(0)}}
-    .sq.shake{animation:shake .18s}
+      /* Board */
+      #board {
+        position: relative;
+        width: 100%;
+        aspect-ratio: 1/1;
+        display: grid;
+        grid-template-columns: repeat(8, 1fr);
+        grid-template-rows: repeat(8, 1fr);
+        border-radius: 12px;
+        overflow: hidden;
+        touch-action: none;
+        cursor: grab;
+        user-select: none;
+      }
+      .sq {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+        font-size: var(--pieceSize);
+      }
+      .sq.light {
+        background: var(--square-light);
+      }
+      .sq.dark {
+        background: var(--square-dark);
+      }
+      .sq.sel {
+        outline: 3px solid rgba(107, 167, 255, 0.95);
+        outline-offset: -3px;
+      }
+      .sq.hover {
+        box-shadow: inset 0 0 0 3px rgba(107, 167, 255, 0.95);
+      }
+      .sq .dot {
+        position: absolute;
+        width: 28%;
+        height: 28%;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.35);
+      }
+      .sq.cap::after {
+        content: "";
+        position: absolute;
+        inset: 10%;
+        border: 3px solid rgba(255, 255, 255, 0.55);
+        border-radius: 50%;
+      }
+      .sq.dragSource {
+        opacity: 0.25;
+      }
+      @keyframes shake {
+        0% {
+          transform: translateX(0);
+        }
+        25% {
+          transform: translateX(-3px);
+        }
+        50% {
+          transform: translateX(3px);
+        }
+        75% {
+          transform: translateX(-3px);
+        }
+        100% {
+          transform: translateX(0);
+        }
+      }
+      .sq.shake {
+        animation: shake 0.18s;
+      }
 
-    /* Unicode chess pieces (black glyphs for both; recolored via CSS) */
-    .piece{
-      font-family:
-        "Noto Sans Symbols2",
-        "Segoe UI Symbol",
-        "DejaVu Sans",
-        "Symbola",
-        "FreeSerif",
-        serif;
-      font-variant-emoji: text;
-    }
-    .sq.pw, .dragPiece.pw{color:#f2f5f8; text-shadow: 0 1px 0 rgba(0,0,0,.6), 0 0 4px rgba(0,0,0,.35)}
-    .sq.pb, .dragPiece.pb{color:#101419; text-shadow: 0 1px 0 rgba(255,255,255,.08), 0 0 2px rgba(255,255,255,.05)}
+      /* Unicode chess pieces (black glyphs for both; recolored via CSS) */
+      .piece {
+        font-family:
+          "Noto Sans Symbols2", "Segoe UI Symbol", "DejaVu Sans", "Symbola",
+          "FreeSerif", serif;
+        font-variant-emoji: text;
+      }
+      .sq.pw,
+      .dragPiece.pw {
+        color: #f2f5f8;
+        text-shadow:
+          0 1px 0 rgba(0, 0, 0, 0.6),
+          0 0 4px rgba(0, 0, 0, 0.35);
+      }
+      .sq.pb,
+      .dragPiece.pb {
+        color: #101419;
+        text-shadow:
+          0 1px 0 rgba(255, 255, 255, 0.08),
+          0 0 2px rgba(255, 255, 255, 0.05);
+      }
 
-    /* Drag ghost */
-    .dragPiece{
-      position:absolute; width:var(--cell); height:var(--cell);
-      display:flex; align-items:center; justify-content:center;
-      font-size:var(--pieceSize); pointer-events:none; filter: drop-shadow(0 6px 10px rgba(0,0,0,.45));
-      transition:none
-    }
-    #board.dragging{cursor:grabbing}
+      /* Drag ghost */
+      .dragPiece {
+        position: absolute;
+        width: var(--cell);
+        height: var(--cell);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: var(--pieceSize);
+        pointer-events: none;
+        filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.45));
+        transition: none;
+      }
+      #board.dragging {
+        cursor: grabbing;
+      }
 
-    /* overlays */
-    .overlay{position:absolute; inset:10px; pointer-events:none}
-    svg.arrow{position:absolute; inset:0; pointer-events:none}
-    .fxCanvas{position:absolute; inset:10px; pointer-events:none; display:none; z-index:25}
+      /* overlays */
+      .overlay {
+        position: absolute;
+        inset: 10px;
+        pointer-events: none;
+      }
+      svg.arrow {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+      }
+      .fxCanvas {
+        position: absolute;
+        inset: 10px;
+        pointer-events: none;
+        display: none;
+        z-index: 25;
+      }
 
-    .evalbar{position:absolute; left:0; top:10px; bottom:10px; width:10px; border-radius:8px; background:#222a36; overflow:hidden; display:none}
-    .evalbar .white{background:#f2f5f8; width:100%; height:50%}
-    .evalbar .black{background:#0c0f14; width:100%; height:50%}
+      .evalbar {
+        position: absolute;
+        left: 0;
+        top: 10px;
+        bottom: 10px;
+        width: 10px;
+        border-radius: 8px;
+        background: #222a36;
+        overflow: hidden;
+        display: none;
+      }
+      .evalbar .white {
+        background: #f2f5f8;
+        width: 100%;
+        height: 50%;
+      }
+      .evalbar .black {
+        background: #0c0f14;
+        width: 100%;
+        height: 50%;
+      }
 
-    /* Promotion */
-    .promo{position:absolute; inset:0; background:rgba(10,14,20,.5); display:none; align-items:center; justify-content:center; z-index:30}
-    .promo .box{background:#0c1118; border:1px solid #1c2533; border-radius:12px; padding:10px; display:flex; gap:8px}
-    .promo .opt{width:56px; height:56px; background:#141a25; border:1px solid #1c2533; border-radius:10px; display:flex; align-items:center; justify-content:center; cursor:pointer; font-size:28px}
+      /* Promotion */
+      .promo {
+        position: absolute;
+        inset: 0;
+        background: rgba(10, 14, 20, 0.5);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 30;
+      }
+      .promo .box {
+        background: #0c1118;
+        border: 1px solid #1c2533;
+        border-radius: 12px;
+        padding: 10px;
+        display: flex;
+        gap: 8px;
+      }
+      .promo .opt {
+        width: 56px;
+        height: 56px;
+        background: #141a25;
+        border: 1px solid #1c2533;
+        border-radius: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        font-size: 28px;
+      }
 
-    /* Cards */
-    .card{
-      background:var(--layer);
-      border:1px solid #222a36;
-      border-radius:12px;
-      padding:14px;
-      width:var(--content-w);
-      max-width:660px;
-      margin-inline:auto;
-      box-shadow:0 4px 12px rgba(0,0,0,.35);
-      backdrop-filter:blur(6px);
-    }
-    @media (min-width: 980px){
-      .card{ width:40vw; max-width:none; }
-    }
-    .row{display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin:8px 0}
-    .row label{min-width:80px}
-    .button-row{justify-content:center}
+      /* Cards */
+      .card {
+        background: var(--layer);
+        border: 1px solid #222a36;
+        border-radius: 12px;
+        padding: 14px;
+        width: var(--content-w);
+        max-width: 660px;
+        margin-inline: auto;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(6px);
+      }
+      @media (min-width: 980px) {
+        .card {
+          width: 40vw;
+          max-width: none;
+        }
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin: 8px 0;
+      }
+      .row label {
+        min-width: 80px;
+      }
+      .button-row {
+        justify-content: center;
+      }
 
-    /* Form controls */
-    select,
-    input[type="text"],
-    input[type="number"],
-    input[type="file"]{
-      background:#1b2432;
-      border:1px solid #2a3443;
-      border-radius:8px;
-      padding:6px 8px;
-      color:var(--text);
-    }
-    input::placeholder{color:var(--muted)}
+      /* Form controls */
+      select,
+      input[type="text"],
+      input[type="number"],
+      input[type="file"] {
+        background: #1b2432;
+        border: 1px solid #2a3443;
+        border-radius: 8px;
+        padding: 6px 8px;
+        color: var(--text);
+      }
+      input::placeholder {
+        color: var(--muted);
+      }
 
-    .pv{font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; font-size:13px}
-    .status{margin-top:6px; min-height:24px}
-    .badge{display:inline-flex; min-width:10px; height:18px; padding:0 6px; align-items:center; justify-content:center; border-radius:999px; background:#112033; border:1px solid #27405c; font-size:12px; color:#cfe2ff}
+      .pv {
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 13px;
+      }
+      .status {
+        margin-top: 6px;
+        min-height: 24px;
+      }
+      .badge {
+        display: inline-flex;
+        min-width: 10px;
+        height: 18px;
+        padding: 0 6px;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        background: #112033;
+        border: 1px solid #27405c;
+        font-size: 12px;
+        color: #cfe2ff;
+      }
 
-    /* Clocks */
-    .player-clock{
-      font-family: 'Orbitron', ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-      font-size:20px;
-      padding:4px 14px;
-      border-radius:8px;
-      border:1px solid #222a36;
-      background:linear-gradient(145deg,#141a25,#0f141c);
-      color:#e8eef5;
-      box-shadow:inset 0 0 6px rgba(0,0,0,.6),0 0 8px rgba(107,167,255,.25);
-      transition:background .2s,color .2s,box-shadow .2s;
-    }
-    .player-clock.white{background:linear-gradient(145deg,#f2f5f8,#cdd3db);color:#0f1216}
-    .player-clock.black{background:linear-gradient(145deg,#1a212f,#0d1118);color:#e8eef5}
-    .player-clock.active{box-shadow:inset 0 0 6px rgba(0,0,0,.6),0 0 12px var(--accent)}
+      /* Clocks */
+      .player-clock {
+        font-family:
+          "Orbitron", ui-monospace, SFMono-Regular, Menlo, Consolas,
+          "Liberation Mono", monospace;
+        font-size: 20px;
+        padding: 4px 14px;
+        border-radius: 8px;
+        border: 1px solid #222a36;
+        background: linear-gradient(145deg, #141a25, #0f141c);
+        color: #e8eef5;
+        box-shadow:
+          inset 0 0 6px rgba(0, 0, 0, 0.6),
+          0 0 8px rgba(107, 167, 255, 0.25);
+        transition:
+          background 0.2s,
+          color 0.2s,
+          box-shadow 0.2s;
+      }
+      .player-clock.white {
+        background: linear-gradient(145deg, #f2f5f8, #cdd3db);
+        color: #0f1216;
+      }
+      .player-clock.black {
+        background: linear-gradient(145deg, #1a212f, #0d1118);
+        color: #e8eef5;
+      }
+      .player-clock.active {
+        box-shadow:
+          inset 0 0 6px rgba(0, 0, 0, 0.6),
+          0 0 12px var(--accent);
+      }
 
-    /* Buttons */
-    button{
-      background:var(--accent);
-      color:var(--bg);
-      border:none;
-      border-radius:8px;
-      padding:6px 12px;
-      font-weight:600;
-      cursor:pointer;
-      box-shadow:0 2px 4px rgba(0,0,0,.25);
-      transition:background .2s, transform .1s, box-shadow .2s;
-    }
-    button:hover{ background:#5b97f0; }
-    button:active{ transform:scale(.97); box-shadow:0 1px 2px rgba(0,0,0,.25); }
-    button.primary{ box-shadow:0 0 8px var(--accent); font-weight:bold; }
+      /* Buttons */
+      button {
+        background: var(--accent);
+        color: var(--bg);
+        border: none;
+        border-radius: 8px;
+        padding: 6px 12px;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+        transition:
+          background 0.2s,
+          transform 0.1s,
+          box-shadow 0.2s;
+      }
+      button:hover {
+        background: #5b97f0;
+      }
+      button:active {
+        transform: scale(0.97);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+      }
+      button.primary {
+        box-shadow: 0 0 8px var(--accent);
+        font-weight: bold;
+      }
 
-    /* Game info text styling */
-    .tip-moves{
-      flex:1;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-      font-size:13px; line-height:1.35;
-      white-space:normal; word-wrap:break-word;
-    }
+      /* Game info text styling */
+      .tip-moves {
+        flex: 1;
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 13px;
+        line-height: 1.35;
+        white-space: normal;
+        word-wrap: break-word;
+      }
 
-    /* Arrow rendering polish */
-    svg .user-arrows line,
-    svg .sys-arrows line { stroke-linecap: round; }
-    svg .user-arrows polygon,
-    svg .sys-arrows polygon { shape-rendering: geometricPrecision; }
+      /* Arrow rendering polish */
+      svg .user-arrows line,
+      svg .sys-arrows line {
+        stroke-linecap: round;
+      }
+      svg .user-arrows polygon,
+      svg .sys-arrows polygon {
+        shape-rendering: geometricPrecision;
+      }
     </style>
-</head>
-<body>
-  <div class="page">
-    <header>
-      <h1>Chess<span class="by-sam">by Sam</span></h1>
-    </header>
+  </head>
+  <body>
+    <div class="page">
+      <header>
+        <h1>Chess<span class="by-sam">by Sam</span></h1>
+      </header>
 
-    <div class="stack">
-      <!-- BOARD FIRST -->
-      <div class="board-area">
-        <div class="player-clock black" id="clockBlack">05:00</div>
-        <div class="board-wrap">
-          <div class="evalbar" id="evalbar">
-            <div class="white" id="evalWhite"></div>
-            <div class="black" id="evalBlack"></div>
-          </div>
+      <div class="stack">
+        <!-- BOARD FIRST -->
+        <div class="board-area">
+          <div class="player-clock black" id="clockBlack">05:00</div>
+          <div class="board-wrap">
+            <div class="evalbar" id="evalbar">
+              <div class="white" id="evalWhite"></div>
+              <div class="black" id="evalBlack"></div>
+            </div>
 
-          <div id="board">
-            <!-- 64 squares created by JS -->
-            <svg class="arrow" id="arrowSvg" viewBox="0 0 800 800" preserveAspectRatio="none"></svg>
-          </div>
-          <canvas id="fireworks" class="fxCanvas" aria-hidden="true"></canvas>
+            <div id="board">
+              <!-- 64 squares created by JS -->
+              <svg
+                class="arrow"
+                id="arrowSvg"
+                viewBox="0 0 800 800"
+                preserveAspectRatio="none"
+              ></svg>
+            </div>
+            <canvas id="fireworks" class="fxCanvas" aria-hidden="true"></canvas>
 
-          <!-- Promotion dialog -->
-          <div class="promo" id="promo">
-            <div class="box">
-              <div class="opt" data-piece="q">♛</div>
-              <div class="opt" data-piece="r">♜</div>
-              <div class="opt" data-piece="b">♝</div>
-              <div class="opt" data-piece="n">♞</div>
+            <!-- Promotion dialog -->
+            <div class="promo" id="promo">
+              <div class="box">
+                <div class="opt" data-piece="q">♛</div>
+                <div class="opt" data-piece="r">♜</div>
+                <div class="opt" data-piece="b">♝</div>
+                <div class="opt" data-piece="n">♞</div>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="player-clock white" id="clockWhite">05:00</div>
-      </div>
-
-      <!-- CONTROLS UNDER THE BOARD -->
-      <div class="card">
-        <div class="row button-row">
-          <label for="side" style="display:none">Your side</label>
-          <select id="side" style="display:none">
-            <option value="white">White</option>
-            <option value="black">Black</option>
-          </select>
-
-          <button id="switchSide" class="switch-btn">Switch to black and restart</button>
+          <div class="player-clock white" id="clockWhite">05:00</div>
         </div>
 
-        <div class="row button-row" id="modeButtons">
-          <button class="btn" data-mode="play">Play vs Engine</button>
-          <button class="btn" data-mode="analysis">Analysis</button>
-          <button class="btn" data-mode="puzzle">Puzzles</button>
-          <select id="mode" style="display:none">
-            <option value="play">Play vs Engine</option>
-            <option value="analysis">Analysis</option>
-            <option value="puzzle">Puzzles</option>
-          </select>
-        </div>
+        <!-- CONTROLS UNDER THE BOARD -->
+        <div class="card">
+          <div class="row button-row">
+            <label for="side" style="display: none">Your side</label>
+            <select id="side" style="display: none">
+              <option value="white">White</option>
+              <option value="black">Black</option>
+            </select>
 
-        <div class="row">
-          <div class="pv" id="pvBox"></div>
-        </div>
-        <div class="row">
-          <label class="muted">Turn</label>
-          <span id="infoTurn">—</span>
-        </div>
-        <div class="row">
-          <label class="muted">Opening</label>
-          <span id="infoOpening">—</span>
-        </div>
-        <div class="row">
-          <label class="muted">Moves</label>
-          <div class="tip-moves" id="infoMoves">—</div>
-        </div>
-
-        <details id="advancedControls">
-          <summary>Advanced</summary>
-          <div class="row">
-            <div id="engineStatus" class="muted">Engine: ready</div>
+            <button id="switchSide" class="switch-btn">
+              Switch to black and restart
+            </button>
           </div>
-          <div class="row" id="knobsRow">
-            <label class="muted">Elo</label>
-            <input type="range" id="elo" min="1" max="100" step="1" value="100" />
-            <span id="eloVal">100%</span>
 
-            <label class="muted">Depth</label>
-            <input type="range" id="depth" min="2" max="22" step="1" value="22" />
-            <span id="depthVal">22</span>
-
-            <label class="muted">MultiPV</label>
-            <input type="range" id="multipv" min="1" max="4" step="1" value="1" />
-            <span id="multipvVal">1</span>
+          <div class="row button-row" id="modeButtons">
+            <button class="btn" data-mode="play">Play vs Engine</button>
+            <button class="btn" data-mode="analysis">Analysis</button>
+            <button class="btn" data-mode="puzzle">Puzzles</button>
+            <select id="mode" style="display: none">
+              <option value="play">Play vs Engine</option>
+              <option value="analysis">Analysis</option>
+              <option value="puzzle">Puzzles</option>
+            </select>
           </div>
 
           <div class="row">
-            <label class="muted">Opening book (offline)</label>
-            <input type="checkbox" id="useBook" checked />
-            <span class="muted">• Play mode only, first ~10 plies</span>
+            <div class="pv" id="pvBox"></div>
           </div>
-
           <div class="row">
-            <label>Clock</label>
-            <input type="number" id="timeMin" value="5" min="1" max="180" />
-            <span class="muted">min</span>
-            <input type="number" id="incSec" value="3" min="0" max="60" />
-            <span class="muted">+ sec</span>
+            <label class="muted">Turn</label>
+            <span id="infoTurn">—</span>
           </div>
-        </details>
-      </div>
+          <div class="row">
+            <label class="muted">Opening</label>
+            <span id="infoOpening">—</span>
+          </div>
+          <div class="row">
+            <label class="muted">Moves</label>
+            <div class="tip-moves" id="infoMoves">—</div>
+          </div>
 
-      <!-- Optional: Game/PGN helpers -->
-      <div class="card">
-        <h3>Game / PGN</h3>
-        <div class="row">
-          <button id="copyPgn">Copy PGN</button>
-          <button id="loadPgn">Load PGN</button>
-          <input id="pgnText" placeholder="Paste PGN here" style="flex:1" />
-        </div>
-        <div class="row">
-          <button id="exportFen">Copy FEN</button>
-          <button id="importFen">Load FEN</button>
-          <input id="fenText" placeholder="Paste FEN here" style="flex:1" />
-        </div>
-      </div>
+          <details id="advancedControls">
+            <summary>Advanced</summary>
+            <div class="row">
+              <div id="engineStatus" class="muted">Engine: ready</div>
+            </div>
+            <div class="row" id="knobsRow">
+              <label class="muted">Elo</label>
+              <input
+                type="range"
+                id="elo"
+                min="1"
+                max="100"
+                step="1"
+                value="100"
+              />
+              <span id="eloVal">100%</span>
 
-      <!-- Puzzles -->
-      <div class="card" id="puzzlePanel" style="display:none">
-        <h3>Puzzles</h3>
-        <div class="row">
-          <button id="fetchDaily">Daily</button>
-          <button id="randomFromPack">Random</button>
-          <button id="nextPuzzle">Next</button>
-          <button id="puzzleHint">Hint</button>
+              <label class="muted">Depth</label>
+              <input
+                type="range"
+                id="depth"
+                min="2"
+                max="22"
+                step="1"
+                value="22"
+              />
+              <span id="depthVal">22</span>
+
+              <label class="muted">MultiPV</label>
+              <input
+                type="range"
+                id="multipv"
+                min="1"
+                max="4"
+                step="1"
+                value="1"
+              />
+              <span id="multipvVal">1</span>
+            </div>
+
+            <div class="row">
+              <label class="muted">Opening book (offline)</label>
+              <input type="checkbox" id="useBook" checked />
+              <span class="muted">• Play mode only, first ~10 plies</span>
+            </div>
+
+            <div class="row">
+              <label>Clock</label>
+              <input type="number" id="timeMin" value="5" min="1" max="180" />
+              <span class="muted">min</span>
+              <input type="number" id="incSec" value="3" min="0" max="60" />
+              <span class="muted">+ sec</span>
+            </div>
+          </details>
         </div>
-        <div class="row">
-          <label>Load by ID:</label>
-          <input id="puzzleIdInput" placeholder="lichess id" />
-          <button id="loadById">Load</button>
+
+        <!-- Optional: Game/PGN helpers -->
+        <div class="card">
+          <h3>Game / PGN</h3>
+          <div class="row">
+            <button id="copyPgn">Copy PGN</button>
+            <button id="loadPgn">Load PGN</button>
+            <input id="pgnText" placeholder="Paste PGN here" style="flex: 1" />
+          </div>
+          <div class="row">
+            <button id="exportFen">Copy FEN</button>
+            <button id="importFen">Load FEN</button>
+            <input id="fenText" placeholder="Paste FEN here" style="flex: 1" />
+          </div>
         </div>
-        <div class="row">
-          <button id="importCsvBtn">Import CSV</button>
-          <input type="file" id="importCsvFile" accept=".csv" />
+
+        <!-- Puzzles -->
+        <div class="card" id="puzzlePanel" style="display: none">
+          <h3>Puzzles</h3>
+          <div class="row">
+            <button id="fetchDaily">Daily</button>
+            <button id="randomFromPack">Start</button>
+            <button id="nextPuzzle">Next</button>
+            <button id="puzzleHint">Hint</button>
+          </div>
+          <div class="row">
+            <label>Load by ID:</label>
+            <input id="puzzleIdInput" placeholder="lichess id" />
+            <button id="loadById">Load</button>
+          </div>
+          <div class="row">
+            <button id="importCsvBtn">Import CSV</button>
+            <input type="file" id="importCsvFile" accept=".csv" />
+          </div>
+          <div class="row">
+            <label>Pack URL:</label>
+            <input id="packUrl" placeholder="https://..." style="flex: 1" />
+            <button id="downloadPackBtn">Download</button>
+            <button id="demoPackBtn">Load sample</button>
+            <button id="sample500Btn">Sample 500</button>
+          </div>
+          <div class="row">
+            <label>Theme</label>
+            <input
+              id="themeFilter"
+              placeholder="mate, fork, pin..."
+              style="flex: 1"
+            />
+            <label>Rating</label>
+            <input
+              id="minRating"
+              placeholder="min"
+              type="number"
+              style="width: 90px"
+            />
+            <input
+              id="maxRating"
+              placeholder="max"
+              type="number"
+              style="width: 90px"
+            />
+          </div>
+          <div class="row">
+            <label>Opening</label>
+            <input
+              id="openingFilter"
+              placeholder="Sicilian, QGD..."
+              style="flex: 1"
+            />
+          </div>
+          <div class="muted" id="packInfo">—</div>
+          <div class="muted" id="puzzleInfo">—</div>
+          <div class="status" id="puzzleStatus"></div>
         </div>
-        <div class="row">
-          <label>Pack URL:</label>
-          <input id="packUrl" placeholder="https://..." style="flex:1" />
-          <button id="downloadPackBtn">Download</button>
-          <button id="demoPackBtn">Load sample</button>
-          <button id="sample500Btn">Sample 500</button>
-        </div>
-        <div class="row">
-          <label>Theme</label>
-          <input id="themeFilter" placeholder="mate, fork, pin..." style="flex:1" />
-          <label>Rating</label>
-          <input id="minRating" placeholder="min" type="number" style="width:90px" />
-          <input id="maxRating" placeholder="max" type="number" style="width:90px" />
-        </div>
-        <div class="muted" id="packInfo">—</div>
-        <div class="muted" id="puzzleInfo">—</div>
-        <div class="status" id="puzzleStatus"></div>
       </div>
+      <footer class="site-footer">
+        <p>
+          Fully offline · No dependencies · Client-side engine ·
+          <a href="https://github.com/samzlotnik/chess-by-z">Open source</a>.
+          Contact:
+          <a href="mailto:itsjustme@samzlotnik.se">itsjustme@samzlotnik.se</a>
+        </p>
+      </footer>
     </div>
-    <footer class="site-footer">
-      <p>Fully offline · No dependencies · Client-side engine · <a href="https://github.com/samzlotnik/chess-by-z">Open source</a>. Contact: <a href="mailto:itsjustme@samzlotnik.se">itsjustme@samzlotnik.se</a></p>
-    </footer>
-  </div>
 
-  <!-- App entry + engine boot (leave these as-is for your current project) -->
-  <script type="module" src="./src/app/App.js"></script>
-  <script type="module" src="./src/engine/boot.js"></script>
-  <script src="./src/ui/DrawOverlay.js" defer></script>
-  <script src="./src/ui/SysArrowPolicy.js" defer></script>
-  <script src="./src/ui/MoveFlash.js" defer></script>
-</body>
+    <!-- App entry + engine boot (leave these as-is for your current project) -->
+    <script type="module" src="./src/app/App.js"></script>
+    <script type="module" src="./src/engine/boot.js"></script>
+    <script src="./src/ui/DrawOverlay.js" defer></script>
+    <script src="./src/ui/SysArrowPolicy.js" defer></script>
+    <script src="./src/ui/MoveFlash.js" defer></script>
+  </body>
 </html>

--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -1,12 +1,12 @@
-import { Game } from '../core/Game.js';
-import { Clock } from '../core/Clock.js';
-import { BoardUI } from '../ui/BoardUI.js';
-import { WorkerEngine } from '../engine/WorkerEngine.js';
-import { PuzzleService } from '../puzzles/PuzzleService.js';
-import { PuzzleUI } from '../puzzles/PuzzleUI.js';
-import { ClockPanel } from '../ui/ClockPanel.js';
-import { detectOpening } from '../engine/Openings.js';
-import { Sounds } from '../util/Sounds.js';
+import { Game } from "../core/Game.js";
+import { Clock } from "../core/Clock.js";
+import { BoardUI } from "../ui/BoardUI.js";
+import { WorkerEngine } from "../engine/WorkerEngine.js";
+import { PuzzleService } from "../puzzles/PuzzleService.js";
+import { PuzzleUI } from "../puzzles/PuzzleUI.js";
+import { ClockPanel } from "../ui/ClockPanel.js";
+import { detectOpening } from "../engine/Openings.js";
+import { Sounds } from "../util/Sounds.js";
 
 const qs = (s) => document.querySelector(s);
 
@@ -15,42 +15,47 @@ export class App {
     window.app = this;
 
     // DOM
-    this.boardEl = qs('#board');
-    this.boardArea = qs('.board-area');
-    this.arrowSvg = qs('#arrowSvg');
-    this.evalbar = qs('#evalbar');
-    this.evalWhite = qs('#evalWhite');
-    this.evalBlack = qs('#evalBlack');
-    this.promo = qs('#promo');
+    this.boardEl = qs("#board");
+    this.boardArea = qs(".board-area");
+    this.arrowSvg = qs("#arrowSvg");
+    this.evalbar = qs("#evalbar");
+    this.evalWhite = qs("#evalWhite");
+    this.evalBlack = qs("#evalBlack");
+    this.promo = qs("#promo");
 
-    this.pvBox = qs('#pvBox');
-    this.engineStatus = qs('#engineStatus');
-    this.infoTurn = qs('#infoTurn');
-    this.infoOpening = qs('#infoOpening');
-    this.infoMoves = qs('#infoMoves');
+    this.pvBox = qs("#pvBox");
+    this.engineStatus = qs("#engineStatus");
+    this.infoTurn = qs("#infoTurn");
+    this.infoOpening = qs("#infoOpening");
+    this.infoMoves = qs("#infoMoves");
 
     // Controls
-    this.modeSel = qs('#mode');
-    this.modeBtns = Array.from(document.querySelectorAll('#modeButtons [data-mode]'));
-    this.sideSel = qs('#side');
-    this.switchBtn = qs('#switchSide');
+    this.modeSel = qs("#mode");
+    this.modeBtns = Array.from(
+      document.querySelectorAll("#modeButtons [data-mode]"),
+    );
+    this.sideSel = qs("#side");
+    this.switchBtn = qs("#switchSide");
     this.confirmRestart = false;
     this.confirmTimeout = null;
-    this.pgnText = qs('#pgnText');
-    this.fenText = qs('#fenText');
+    this.pgnText = qs("#pgnText");
+    this.fenText = qs("#fenText");
 
     // Engine knobs
-    this.elo = qs('#elo'); this.eloVal = qs('#eloVal');
-    this.depth = qs('#depth'); this.depthVal = qs('#depthVal');
-    this.multipv = qs('#multipv'); this.multipvVal = qs('#multipvVal');
+    this.elo = qs("#elo");
+    this.eloVal = qs("#eloVal");
+    this.depth = qs("#depth");
+    this.depthVal = qs("#depthVal");
+    this.multipv = qs("#multipv");
+    this.multipvVal = qs("#multipvVal");
 
     // Clock UI elements
     const clockEls = {
-      white: qs('#clockWhite'),
-      black: qs('#clockBlack'),
-      timeMin: qs('#timeMin'),
-      incSec: qs('#incSec'),
-      turnSupplier: () => this.game.turn()
+      white: qs("#clockWhite"),
+      black: qs("#clockBlack"),
+      timeMin: qs("#timeMin"),
+      incSec: qs("#incSec"),
+      turnSupplier: () => this.game.turn(),
     };
 
     // Core
@@ -58,7 +63,8 @@ export class App {
     this.clock = new Clock();
     // Allow switching between classic and strong engine via ?engine=strong
     const params = new URLSearchParams(window.location.search);
-    const engineVariant = params.get('engine') === 'strong' ? 'strong' : 'classic';
+    const engineVariant =
+      params.get("engine") === "strong" ? "strong" : "classic";
     this.engine = new WorkerEngine({ variant: engineVariant });
     this.sounds = new Sounds();
 
@@ -67,7 +73,8 @@ export class App {
     this.clock.onFlag = (side) => {
       this.engine.stop?.();
       this.gameOver = true;
-      this.engineStatus.textContent = (side === 'w') ? 'White flagged.' : 'Black flagged.';
+      this.engineStatus.textContent =
+        side === "w" ? "White flagged." : "Black flagged.";
     };
     this.clockPanel.render();
 
@@ -76,11 +83,15 @@ export class App {
       boardEl: this.boardEl,
       arrowSvg: this.arrowSvg,
       promoEl: this.promo,
-      evalbar: { root: this.evalbar, white: this.evalWhite, black: this.evalBlack },
+      evalbar: {
+        root: this.evalbar,
+        white: this.evalWhite,
+        black: this.evalBlack,
+      },
       onUserMove: this.onUserMove.bind(this),
       getPieceAt: this.getPieceAt.bind(this),
       getLegalTargets: this.getLegalTargets.bind(this),
-      cancelPreMove: this.cancelPreMove.bind(this)
+      cancelPreMove: this.cancelPreMove.bind(this),
     });
     this.applyOrientation();
     this.updateSwitchButtonText();
@@ -88,30 +99,46 @@ export class App {
     // Puzzles
     this.puzzleService = new PuzzleService();
     this.puzzles = new PuzzleUI({
-      game: this.game, ui: this.ui, service: this.puzzleService,
+      game: this.game,
+      ui: this.ui,
+      service: this.puzzleService,
       dom: {
-        panel: qs('#puzzlePanel'), fetchDailyBtn: qs('#fetchDaily'),
-        loadByIdBtn: qs('#loadById'), puzzleIdInput: qs('#puzzleIdInput'),
-        importCsvBtn: qs('#importCsvBtn'), importCsvFile: qs('#importCsvFile'),
-        packInfo: qs('#packInfo'), packUrlInput: qs('#packUrl'),
-        downloadPackBtn: qs('#downloadPackBtn'), demoPackBtn: qs('#demoPackBtn'),
-        sample500Btn: qs('#sample500Btn'), themeFilter: qs('#themeFilter'),
-        minRating: qs('#minRating'), maxRating: qs('#maxRating'),
-        randomFromPackBtn: qs('#randomFromPack'), nextPuzzleBtn: qs('#nextPuzzle'),
-        hintBtn: qs('#puzzleHint'), puzzleInfo: qs('#puzzleInfo'), puzzleStatus: qs('#puzzleStatus')
+        panel: qs("#puzzlePanel"),
+        fetchDailyBtn: qs("#fetchDaily"),
+        loadByIdBtn: qs("#loadById"),
+        puzzleIdInput: qs("#puzzleIdInput"),
+        importCsvBtn: qs("#importCsvBtn"),
+        importCsvFile: qs("#importCsvFile"),
+        packInfo: qs("#packInfo"),
+        packUrlInput: qs("#packUrl"),
+        downloadPackBtn: qs("#downloadPackBtn"),
+        demoPackBtn: qs("#demoPackBtn"),
+        sample500Btn: qs("#sample500Btn"),
+        themeFilter: qs("#themeFilter"),
+        openingFilter: qs("#openingFilter"),
+        minRating: qs("#minRating"),
+        maxRating: qs("#maxRating"),
+        randomFromPackBtn: qs("#randomFromPack"),
+        nextPuzzleBtn: qs("#nextPuzzle"),
+        hintBtn: qs("#puzzleHint"),
+        puzzleInfo: qs("#puzzleInfo"),
+        puzzleStatus: qs("#puzzleStatus"),
       },
-      onStateChanged: () => { this.syncBoard(); this.refreshAll(); },
+      onStateChanged: () => {
+        this.syncBoard();
+        this.refreshAll();
+      },
       onMove: (mv) => this.playMoveSound(mv),
       onPuzzleLoad: (turn) => {
-        this.sideSel.value = (turn === 'w') ? 'white' : 'black';
+        this.sideSel.value = turn === "w" ? "white" : "black";
         this.updateSwitchButtonText();
-      }
+      },
     });
 
     // --- REVIEW MODE state ---
-    this.inReview = false;      // true when viewing a past position
-    this.reviewPly = 0;         // which half-move (ply) we’re viewing
-    this.reviewFen = null;      // cached FEN of the viewed position
+    this.inReview = false; // true when viewing a past position
+    this.reviewPly = 0; // which half-move (ply) we’re viewing
+    this.reviewFen = null; // cached FEN of the viewed position
 
     // Celebration guard (fireworks once per final ply)
     this.lastCelebrationPly = -1;
@@ -123,32 +150,46 @@ export class App {
     this.bindReviewHotkeys();
 
     // --- Drawing hotkeys ---
-    window.addEventListener('keydown', (e) => {
+    window.addEventListener("keydown", (e) => {
       const t = e.target;
       // don't hijack when typing
-      if (t && (/^(INPUT|TEXTAREA|SELECT)$/).test(t.tagName)) return;
+      if (t && /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName)) return;
 
       // Clear drawings: X
-      if ((e.key === 'x' || e.key === 'X') && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey){
+      if (
+        (e.key === "x" || e.key === "X") &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.shiftKey
+      ) {
         e.preventDefault();
         this.ui.clearUserArrows?.();
         this.ui.clearUserCircles?.();
       }
 
       // Export drawings JSON: ⌘/Ctrl+E
-      if ((e.key === 'e' || e.key === 'E') && (e.metaKey || e.ctrlKey)){
+      if ((e.key === "e" || e.key === "E") && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        const data = this.ui.getUserDrawings?.() || {arrows:[], circles:[]};
-        try { navigator.clipboard?.writeText(JSON.stringify(data, null, 2)); this.engineStatus.textContent = 'Copied drawings JSON'; } catch {}
+        const data = this.ui.getUserDrawings?.() || { arrows: [], circles: [] };
+        try {
+          navigator.clipboard?.writeText(JSON.stringify(data, null, 2));
+          this.engineStatus.textContent = "Copied drawings JSON";
+        } catch {}
       }
 
       // Import drawings JSON: ⌘/Ctrl+I
-      if ((e.key === 'i' || e.key === 'I') && (e.metaKey || e.ctrlKey)){
+      if ((e.key === "i" || e.key === "I") && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        const txt = prompt('Paste drawings JSON ({arrows:[{uci,color}], circles:[{sq,color}]})');
+        const txt = prompt(
+          "Paste drawings JSON ({arrows:[{uci,color}], circles:[{sq,color}]})",
+        );
         if (!txt) return;
-        try { this.ui.setUserDrawings?.(JSON.parse(txt)); }
-        catch { this.engineStatus.textContent = 'Invalid drawings JSON'; }
+        try {
+          this.ui.setUserDrawings?.(JSON.parse(txt));
+        } catch {
+          this.engineStatus.textContent = "Invalid drawings JSON";
+        }
       }
     });
     this.bindBoardClickExitReview();
@@ -158,115 +199,126 @@ export class App {
     this.updateModeButtonStyles();
 
     // Do NOT start clocks yet; only after the human makes their first move.
-    if (this.modeSel.value === 'play') {
+    if (this.modeSel.value === "play") {
       this.maybeEngineMove();
     }
   }
 
-  bindControls(){
+  bindControls() {
     const link = (el, label, after) => {
-      const f = () => { label.textContent = el.value; after && after(); };
-      el.addEventListener('input', f); f();
+      const f = () => {
+        label.textContent = el.value;
+        after && after();
+      };
+      el.addEventListener("input", f);
+      f();
     };
     link(this.elo, this.eloVal);
     link(this.depth, this.depthVal);
     link(this.multipv, this.multipvVal);
 
-    this.modeBtns.forEach(btn => btn.addEventListener('click', () => this.setMode(btn.dataset.mode)));
+    this.modeBtns.forEach((btn) =>
+      btn.addEventListener("click", () => this.setMode(btn.dataset.mode)),
+    );
 
-    this.modeSel.addEventListener('change', async () => {
+    this.modeSel.addEventListener("change", async () => {
       const m = this.modeSel.value;
-      this.puzzles.show(m === 'puzzle');
-      if (m === 'play') { this.maybeEngineMove(); }
-      else this.clock.pause();
-      if (m === 'puzzle') {
+      this.puzzles.show(m === "puzzle");
+      if (m === "play") {
+        this.maybeEngineMove();
+      } else this.clock.pause();
+      if (m === "puzzle") {
         this.puzzles.resetProgress();
         this.clockPanel.pause();
         try {
           const p = await this.puzzleService.fetchDaily();
           await this.puzzles.loadConvertedPuzzle(p);
         } catch (e) {
-          this.engineStatus.textContent = 'Daily puzzle fetch failed';
+          this.engineStatus.textContent = "Daily puzzle fetch failed";
         }
       }
       this.refreshAll();
       this.updateModeButtonStyles();
     });
 
-    this.sideSel.addEventListener('change', () => {
+    this.sideSel.addEventListener("change", () => {
       this.applyOrientation();
       this.refreshAll();
       this.maybeEngineMove();
       this.updateSwitchButtonText();
     });
 
-    this.switchBtn.addEventListener('click', () => {
+    this.switchBtn.addEventListener("click", () => {
       if (this.confirmRestart) {
         clearTimeout(this.confirmTimeout);
         this.confirmRestart = false;
-        this.switchBtn.classList.remove('confirm');
-        this.sideSel.value = (this.sideSel.value === 'white') ? 'black' : 'white';
+        this.switchBtn.classList.remove("confirm");
+        this.sideSel.value = this.sideSel.value === "white" ? "black" : "white";
         this.applyOrientation();
         this.startNewGame();
         this.updateSwitchButtonText();
       } else {
         this.confirmRestart = true;
-        this.switchBtn.textContent = 'Restart?';
-        this.switchBtn.classList.add('confirm');
+        this.switchBtn.textContent = "Restart?";
+        this.switchBtn.classList.add("confirm");
         this.confirmTimeout = setTimeout(() => {
           this.confirmRestart = false;
-          this.switchBtn.classList.remove('confirm');
+          this.switchBtn.classList.remove("confirm");
           this.updateSwitchButtonText();
         }, 2000);
       }
     });
 
     // PGN / FEN helpers
-    qs('#copyPgn').addEventListener('click', () => {
+    qs("#copyPgn").addEventListener("click", () => {
       const pgn = this.game.pgn();
       this.pgnText.value = pgn;
-      try { navigator.clipboard?.writeText(pgn); this.engineStatus.textContent = 'PGN copied'; }
-      catch {}
+      try {
+        navigator.clipboard?.writeText(pgn);
+        this.engineStatus.textContent = "PGN copied";
+      } catch {}
     });
-    qs('#loadPgn').addEventListener('click', () => {
+    qs("#loadPgn").addEventListener("click", () => {
       const txt = this.pgnText.value.trim();
       if (!txt) return;
       if (this.game.loadPgn(txt)) {
         this.exitReview();
         this.syncBoard();
         this.refreshAll();
-        this.engineStatus.textContent = 'PGN loaded';
+        this.engineStatus.textContent = "PGN loaded";
       } else {
-        this.engineStatus.textContent = 'Invalid PGN';
+        this.engineStatus.textContent = "Invalid PGN";
       }
     });
-    qs('#exportFen').addEventListener('click', () => {
+    qs("#exportFen").addEventListener("click", () => {
       const fen = this.game.fen();
       this.fenText.value = fen;
-      try { navigator.clipboard?.writeText(fen); this.engineStatus.textContent = 'FEN copied'; }
-      catch {}
+      try {
+        navigator.clipboard?.writeText(fen);
+        this.engineStatus.textContent = "FEN copied";
+      } catch {}
     });
-    qs('#importFen').addEventListener('click', () => {
+    qs("#importFen").addEventListener("click", () => {
       const txt = this.fenText.value.trim();
       if (!txt) return;
       if (this.game.load(txt)) {
         this.exitReview();
         this.syncBoard();
         this.refreshAll();
-        this.engineStatus.textContent = 'FEN loaded';
+        this.engineStatus.textContent = "FEN loaded";
       } else {
-        this.engineStatus.textContent = 'Invalid FEN';
+        this.engineStatus.textContent = "Invalid FEN";
       }
     });
   }
 
-  applyOrientation(){
+  applyOrientation() {
     const side = this.sideSel.value;
     this.ui.setOrientation(side);
-    this.boardArea.classList.toggle('flipped', side === 'black');
+    this.boardArea.classList.toggle("flipped", side === "black");
   }
 
-  startNewGame(){
+  startNewGame() {
     this.exitReview();
     this.lastCelebrationPly = -1;
     this.gameOver = false;
@@ -279,83 +331,87 @@ export class App {
     this.refreshAll();
     this.clockPanel.applyInputs?.();
     this.clockPanel.render();
-    if (this.modeSel.value === 'analysis') this.requestAnalysis();
-    else if (this.modeSel.value === 'play') { this.maybeEngineMove(); }
-    else if (this.modeSel.value === 'puzzle') { this.puzzles.resetProgress(); this.clockPanel.pause(); }
+    if (this.modeSel.value === "analysis") this.requestAnalysis();
+    else if (this.modeSel.value === "play") {
+      this.maybeEngineMove();
+    } else if (this.modeSel.value === "puzzle") {
+      this.puzzles.resetProgress();
+      this.clockPanel.pause();
+    }
   }
 
-  updateSwitchButtonText(){
-    const next = (this.sideSel.value === 'white') ? 'black' : 'white';
+  updateSwitchButtonText() {
+    const next = this.sideSel.value === "white" ? "black" : "white";
     this.switchBtn.textContent = `Switch to ${next} and restart`;
   }
 
-  setMode(mode){
+  setMode(mode) {
     if (this.modeSel.value === mode) return;
     this.modeSel.value = mode;
-    this.modeSel.dispatchEvent(new Event('change'));
+    this.modeSel.dispatchEvent(new Event("change"));
   }
 
-  updateModeButtonStyles(){
-    this.modeBtns?.forEach(btn => {
-      btn.classList.toggle('primary', btn.dataset.mode === this.modeSel.value);
+  updateModeButtonStyles() {
+    this.modeBtns?.forEach((btn) => {
+      btn.classList.toggle("primary", btn.dataset.mode === this.modeSel.value);
     });
   }
 
   // === Review hotkeys & click-to-exit ===
-  bindReviewHotkeys(){
-    window.addEventListener('keydown', (e) => {
+  bindReviewHotkeys() {
+    window.addEventListener("keydown", (e) => {
       // Ignore when typing in inputs
       const t = e.target;
-      if (t && (/^(INPUT|TEXTAREA|SELECT)$/).test(t.tagName)) return;
+      if (t && /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName)) return;
       if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
 
       const key = e.key;
       const histLen = this.getSanHistory().length;
 
-      if (key === 'ArrowLeft'){
+      if (key === "ArrowLeft") {
         e.preventDefault();
-        if (!this.inReview){
-          if (histLen === 0) return;          // nothing to review
-          this.enterReviewAt(histLen - 1);    // go to last completed ply
+        if (!this.inReview) {
+          if (histLen === 0) return; // nothing to review
+          this.enterReviewAt(histLen - 1); // go to last completed ply
         } else {
           this.setReviewPly(Math.max(0, this.reviewPly - 1));
         }
-      }
-      else if (key === 'ArrowRight'){
+      } else if (key === "ArrowRight") {
         e.preventDefault();
         if (!this.inReview) return; // already live; nothing forward
         const next = Math.min(histLen, this.reviewPly + 1);
-        if (next === histLen) this.exitReview(); else this.setReviewPly(next);
+        if (next === histLen) this.exitReview();
+        else this.setReviewPly(next);
       }
     });
   }
 
-  bindBoardClickExitReview(){
-    this.boardEl?.addEventListener('click', () => {
+  bindBoardClickExitReview() {
+    this.boardEl?.addEventListener("click", () => {
       if (this.inReview) this.exitReview();
     });
   }
 
   // === Review helpers ===
-  enterReviewAt(ply){
+  enterReviewAt(ply) {
     this.inReview = true;
     this.setReviewPly(ply);
     // Disable interaction on the board (no moves while reviewing)
     this.ui.onUserMove = () => false;
-    this.ui.getPieceAt = () => null;         // prevent drag start
-    this.ui.getLegalTargets = () => [];      // no dots/highlights for moves
+    this.ui.getPieceAt = () => null; // prevent drag start
+    this.ui.getLegalTargets = () => []; // no dots/highlights for moves
   }
 
-  setReviewPly(ply){
+  setReviewPly(ply) {
     const hist = this.getSanHistory();
-    const clamped = Math.max(0, Math.min(hist.length, ply|0));
+    const clamped = Math.max(0, Math.min(hist.length, ply | 0));
     this.reviewPly = clamped;
     this.reviewFen = this.buildFenFromSan(hist.slice(0, clamped));
-    this.syncBoard();     // will display review FEN
-    this.refreshAll();    // updates popover with sliced moves
+    this.syncBoard(); // will display review FEN
+    this.refreshAll(); // updates popover with sliced moves
   }
 
-  exitReview(){
+  exitReview() {
     if (!this.inReview) return;
     this.inReview = false;
     this.reviewFen = null;
@@ -365,26 +421,28 @@ export class App {
     this.ui.getPieceAt = this.getPieceAt.bind(this);
     this.ui.getLegalTargets = this.getLegalTargets.bind(this);
 
-    this.syncBoard();   // back to live fen
+    this.syncBoard(); // back to live fen
     this.refreshAll();
     this.maybeEngineMove(); // if engine to move, resume
   }
 
-  getActiveFen(){
+  getActiveFen() {
     return this.inReview && this.reviewFen ? this.reviewFen : this.game.fen();
   }
 
-  buildFenFromSan(sanList){
+  buildFenFromSan(sanList) {
     // Rebuild a position from SANs using a temporary Game instance
     const g = new Game();
-    for (const san of sanList){ g.moveSan(san); }
+    for (const san of sanList) {
+      g.moveSan(san);
+    }
     return g.fen();
   }
 
-  getPieceAt(sq){
+  getPieceAt(sq) {
     const p = this.game.get(sq);
-    if (this.modeSel.value === 'play'){
-      const human = (this.sideSel.value === 'white') ? 'w' : 'b';
+    if (this.modeSel.value === "play") {
+      const human = this.sideSel.value === "white" ? "w" : "b";
       if (!p || p.color !== human) return null;
       return p;
     }
@@ -393,12 +451,12 @@ export class App {
     return p;
   }
 
-  getLegalTargets(sq){
+  getLegalTargets(sq) {
     const p = this.game.get(sq);
-    if (this.modeSel.value === 'play'){
-      const human = (this.sideSel.value === 'white') ? 'w' : 'b';
+    if (this.modeSel.value === "play") {
+      const human = this.sideSel.value === "white" ? "w" : "b";
       if (!p || p.color !== human) return [];
-      if (this.game.turn() !== human){
+      if (this.game.turn() !== human) {
         return this.game.premoveLegalMovesFrom(sq, human);
       }
       return this.game.legalMovesFrom(sq, human);
@@ -408,46 +466,51 @@ export class App {
     return this.game.legalMovesFrom(sq);
   }
 
-  playMoveSound(mv){
+  playMoveSound(mv) {
     if (this.isMateNow()) return; // celebration handles the sound
-    if (this.isCheckNow()) this.sounds.play('check');
-    else this.sounds.play(mv?.captured ? 'capture' : 'move');
+    if (this.isCheckNow()) this.sounds.play("check");
+    else this.sounds.play(mv?.captured ? "capture" : "move");
   }
 
   onUserMove({ from, to, promotion }) {
     if (this.inReview || this.gameOver) return false; // safety net
-    if (this.modeSel.value === 'play'){
-      const human = (this.sideSel.value === 'white') ? 'w' : 'b';
-      if (this.game.turn() !== human){
-        this.preMove = { from, to, promotion: promotion || 'q' };
+    if (this.modeSel.value === "play") {
+      const human = this.sideSel.value === "white" ? "w" : "b";
+      if (this.game.turn() !== human) {
+        this.preMove = { from, to, promotion: promotion || "q" };
         this.ui.markPreMove?.(from, to);
         return true;
       }
     }
-    const mv = this.game.move({ from, to, promotion: promotion || 'q' });
+    const mv = this.game.move({ from, to, promotion: promotion || "q" });
     if (!mv) return false;
     this.playMoveSound(mv);
 
-    if (this.modeSel.value === 'play') { this.clock.onMoveApplied(); this.clockPanel.startIfNotRunning(); }
-    if (this.modeSel.value === 'puzzle') {
+    if (this.modeSel.value === "play") {
+      this.clock.onMoveApplied();
+      this.clockPanel.startIfNotRunning();
+    }
+    if (this.modeSel.value === "puzzle") {
       const ok = this.puzzles.handleUserMove(mv);
-      this.syncBoard(); this.refreshAll();
+      this.syncBoard();
+      this.refreshAll();
       this.maybeCelebrate(); // celebration for puzzle mates as well
       this.checkGameOver();
       this.applyPreMove();
       return ok;
     }
 
-    this.syncBoard(); this.refreshAll();
+    this.syncBoard();
+    this.refreshAll();
     this.maybeCelebrate();
     this.checkGameOver();
-    if (this.modeSel.value === 'analysis') this.requestAnalysis();
-    else if (this.modeSel.value === 'play') this.maybeEngineMove();
+    if (this.modeSel.value === "analysis") this.requestAnalysis();
+    else if (this.modeSel.value === "play") this.maybeEngineMove();
     this.applyPreMove();
     return true;
   }
 
-  applyPreMove(){
+  applyPreMove() {
     if (!this.preMove) return;
     const mv = this.preMove;
     this.preMove = null;
@@ -456,37 +519,43 @@ export class App {
     this.onUserMove(mv);
   }
 
-  cancelPreMove(){
+  cancelPreMove() {
     if (!this.preMove) return false;
     this.preMove = null;
     this.ui.clearPreMove?.();
     return true;
   }
 
-  maybeEngineMove(){
-    if (this.modeSel.value !== 'play') return;
+  maybeEngineMove() {
+    if (this.modeSel.value !== "play") return;
     if (this.inReview || this.gameOver) return; // don't move engine while browsing history
-    const humanIs = (this.sideSel.value === 'white') ? 'w' : 'b';
+    const humanIs = this.sideSel.value === "white" ? "w" : "b";
     if (this.game.turn() !== humanIs) this.requestBestMove();
   }
 
   // === Opening book: ask boot.js for a SAN move before calling the engine
-  askBookMove(){
+  askBookMove() {
     return new Promise((resolve) => {
       const onMove = (ev) => resolve(ev?.detail?.san || null);
-      window.addEventListener('book:move', onMove, { once: true });
+      window.addEventListener("book:move", onMove, { once: true });
       const hist = this.getSanHistory();
-      window.dispatchEvent(new CustomEvent('book:request', {
-        detail: { sanHistory: hist.join(' '), ply: hist.length, mode: this.modeSel.value }
-      }));
+      window.dispatchEvent(
+        new CustomEvent("book:request", {
+          detail: {
+            sanHistory: hist.join(" "),
+            ply: hist.length,
+            mode: this.modeSel.value,
+          },
+        }),
+      );
       setTimeout(() => resolve(null), 25); // tolerate missing listener
     });
   }
 
-  async requestBestMove(){
-    try{
+  async requestBestMove() {
+    try {
       if (this.inReview || this.gameOver) return; // safety
-      this.engineStatus.textContent = 'Engine thinking...';
+      this.engineStatus.textContent = "Engine thinking...";
 
       // 1) Try the opening book first
       const san = await this.askBookMove();
@@ -495,164 +564,189 @@ export class App {
         if (mv) {
           this.clock.onMoveApplied?.();
           const last = this.game.historyVerbose?.().slice(-1)[0] || mv;
-          if (last?.from && last?.to) this.ui.drawArrowUci(last.from + last.to + (last.promotion||''), true);
+          if (last?.from && last?.to)
+            this.ui.drawArrowUci(
+              last.from + last.to + (last.promotion || ""),
+              true,
+            );
           this.playMoveSound(mv);
-          this.syncBoard(); this.refreshAll();
+          this.syncBoard();
+          this.refreshAll();
           this.maybeCelebrate();
           this.checkGameOver();
           this.applyPreMove();
-          this.engineStatus.textContent = 'Book move';
+          this.engineStatus.textContent = "Book move";
           return;
         }
       }
 
       // 2) Fall back to the engine
-      const eloPct = parseInt(this.elo.value,10);
-      const mapped = window.engineTuner?.mapElo ? window.engineTuner.mapElo(eloPct) : { elo: 3000 };
+      const eloPct = parseInt(this.elo.value, 10);
+      const mapped = window.engineTuner?.mapElo
+        ? window.engineTuner.mapElo(eloPct)
+        : { elo: 3000 };
       const uci = await this.engine.play(this.game.fen(), {
         elo: mapped.elo,
-        depthCap: parseInt(this.depth.value,10),
-        timeLeftMs: (this.clock.turn === 'w') ? this.clock.white : this.clock.black,
-        incrementMs: this.clock.inc
+        depthCap: parseInt(this.depth.value, 10),
+        timeLeftMs:
+          this.clock.turn === "w" ? this.clock.white : this.clock.black,
+        incrementMs: this.clock.inc,
       });
       if (uci) {
         const mv = this.game.moveUci(uci);
-        if (this.modeSel.value === 'play') this.clock.onMoveApplied();
+        if (this.modeSel.value === "play") this.clock.onMoveApplied();
         this.playMoveSound(mv);
-        this.syncBoard(); this.refreshAll();
+        this.syncBoard();
+        this.refreshAll();
         this.ui.drawArrowUci(uci, true);
         this.maybeCelebrate();
         this.checkGameOver();
         this.applyPreMove();
       }
-      this.engineStatus.textContent = 'Engine: move played';
-    }catch(e){
-      this.engineStatus.textContent = 'Engine error: ' + e.message;
+      this.engineStatus.textContent = "Engine: move played";
+    } catch (e) {
+      this.engineStatus.textContent = "Engine error: " + e.message;
       console.error(e);
     }
   }
 
-  async requestAnalysis(){
-    try{
+  async requestAnalysis() {
+    try {
       if (this.inReview || this.gameOver) return; // keep analysis tied to current position only
-      this.engineStatus.textContent = 'Analyzing...';
+      this.engineStatus.textContent = "Analyzing...";
       const lines = await this.engine.analyze(this.game.fen(), {
-        depth: parseInt(this.depth.value,10),
-        multipv: parseInt(this.multipv.value,10),
-        timeMs: window.engineTuner?.lastMovetime || 300
+        depth: parseInt(this.depth.value, 10),
+        multipv: parseInt(this.multipv.value, 10),
+        timeMs: window.engineTuner?.lastMovetime || 300,
       });
       this.ui.clearArrow?.();
-      (lines||[]).forEach((l,i)=> { if (l.firstUci) this.ui.drawArrowUci(l.firstUci, i===0); });
+      (lines || []).forEach((l, i) => {
+        if (l.firstUci) this.ui.drawArrowUci(l.firstUci, i === 0);
+      });
       if (lines && lines[0]) this.updateEvalFromCp(lines[0].scoreCp);
-      this.engineStatus.textContent = 'Engine: ready';
+      this.engineStatus.textContent = "Engine: ready";
 
-      this.pvBox.innerHTML = (lines || []).map((it, i) =>
-        `<div>PV${i + 1}: <b>${(it.scoreCp / 100).toFixed(2)}</b> — <span class="muted">${(it.san || []).join(' ')}</span></div>`
-      ).join('');
-    }catch(e){
-      this.engineStatus.textContent = 'Engine error: ' + e.message;
+      this.pvBox.innerHTML = (lines || [])
+        .map(
+          (it, i) =>
+            `<div>PV${i + 1}: <b>${(it.scoreCp / 100).toFixed(2)}</b> — <span class="muted">${(it.san || []).join(" ")}</span></div>`,
+        )
+        .join("");
+    } catch (e) {
+      this.engineStatus.textContent = "Engine error: " + e.message;
       console.error(e);
     }
   }
 
-  async requestHint(){
-    try{
+  async requestHint() {
+    try {
       if (this.inReview || this.gameOver) return;
-      this.engineStatus.textContent = 'Hint...';
+      this.engineStatus.textContent = "Hint...";
       const lines = await this.engine.analyze(this.game.fen(), {
-        depth: Math.max(2, parseInt(this.depth.value,10)),
+        depth: Math.max(2, parseInt(this.depth.value, 10)),
         multipv: 1,
-        timeMs: window.engineTuner?.lastMovetime || 300
+        timeMs: window.engineTuner?.lastMovetime || 300,
       });
       if (lines && lines[0]?.firstUci) this.ui.drawArrowUci(lines[0].firstUci);
       if (lines && lines[0]) this.updateEvalFromCp(lines[0].scoreCp);
-      this.engineStatus.textContent = 'Engine: ready';
-    }catch(e){
-      this.engineStatus.textContent = 'Engine error: ' + e.message;
+      this.engineStatus.textContent = "Engine: ready";
+    } catch (e) {
+      this.engineStatus.textContent = "Engine error: " + e.message;
       console.error(e);
     }
   }
 
-  updateEvalFromCp(cp){
-    const clamped = Math.max(-1000, Math.min(1000, cp|0));
-    const pct = 50 + (clamped/20);
-    this.evalbar.style.display = 'block';
+  updateEvalFromCp(cp) {
+    const clamped = Math.max(-1000, Math.min(1000, cp | 0));
+    const pct = 50 + clamped / 20;
+    this.evalbar.style.display = "block";
     this.evalWhite.style.height = `${Math.max(0, Math.min(100, pct))}%`;
-    this.evalBlack.style.height = `${Math.max(0, Math.min(100, 100-pct))}%`;
+    this.evalBlack.style.height = `${Math.max(0, Math.min(100, 100 - pct))}%`;
   }
 
-  syncBoard(){
+  syncBoard() {
     this.applyOrientation();
     this.ui.setFen(this.getActiveFen());
     const ply = this.inReview ? this.reviewPly : this.getSanHistory().length;
     const inst = window.DrawOverlayInstance;
-    if (inst && typeof inst.restoreSnapshotForPly === 'function') inst.restoreSnapshotForPly(ply);
+    if (inst && typeof inst.restoreSnapshotForPly === "function")
+      inst.restoreSnapshotForPly(ply);
   }
 
-  refreshAll(){
+  refreshAll() {
     this.updateStatusMinimal();
     this.updateGameInfo();
   }
 
-  updateStatusMinimal(){
+  updateStatusMinimal() {
     // Minimal status; detailed info is in the card.
   }
 
-  updateGameInfo(){
+  updateGameInfo() {
     if (!this.infoTurn || !this.infoOpening || !this.infoMoves) return;
 
     // 1) Turn
     let turnSide;
-    if (this.inReview){
-      turnSide = (this.reviewPly % 2 === 0) ? 'White' : 'Black';
+    if (this.inReview) {
+      turnSide = this.reviewPly % 2 === 0 ? "White" : "Black";
     } else {
-      turnSide = (this.game.turn() === 'w') ? 'White' : 'Black';
+      turnSide = this.game.turn() === "w" ? "White" : "Black";
     }
 
     // 2) Opening (best prefix match)
     const sanHistFull = this.getSanHistory();
-    const sanHist = this.inReview ? sanHistFull.slice(0, this.reviewPly) : sanHistFull;
-    const openingName = detectOpening(sanHist) || '—';
+    const sanHist = this.inReview
+      ? sanHistFull.slice(0, this.reviewPly)
+      : sanHistFull;
+    const openingName = detectOpening(sanHist) || "—";
 
     // 3) Moves (numbered, compact)
-    const movesText = this.formatMoves(sanHist) || '—';
+    const movesText = this.formatMoves(sanHist) || "—";
 
-    this.infoTurn.textContent = turnSide + (this.inReview ? ' (review)' : '');
+    this.infoTurn.textContent = turnSide + (this.inReview ? " (review)" : "");
     this.infoOpening.textContent = openingName;
     this.infoMoves.textContent = movesText;
   }
 
-  getSanHistory(){
-    if (typeof this.game.history === 'function') {
+  getSanHistory() {
+    if (typeof this.game.history === "function") {
       const h = this.game.history();
       if (Array.isArray(h)) return h;
     }
-    if (this.game.ch && typeof this.game.ch.history === 'function') {
+    if (this.game.ch && typeof this.game.ch.history === "function") {
       const h = this.game.ch.history();
       if (Array.isArray(h)) return h;
     }
-    const pgn = (typeof this.game.pgn === 'function') ? String(this.game.pgn() || '') : '';
-    const tail = pgn.split('\n\n').pop() || '';
-    return tail.trim().split(/\s+/).filter(x => !/^\d+\.(\.\.)?$/.test(x) && x !== '*');
+    const pgn =
+      typeof this.game.pgn === "function" ? String(this.game.pgn() || "") : "";
+    const tail = pgn.split("\n\n").pop() || "";
+    return tail
+      .trim()
+      .split(/\s+/)
+      .filter((x) => !/^\d+\.(\.\.)?$/.test(x) && x !== "*");
   }
 
-  formatMoves(sanList){
-    if (!sanList || !sanList.length) return '';
+  formatMoves(sanList) {
+    if (!sanList || !sanList.length) return "";
     let out = [];
     let num = 1;
     for (let i = 0; i < sanList.length; i += 2) {
-      const white = sanList[i] || '';
-      const black = sanList[i+1] || '';
+      const white = sanList[i] || "";
+      const black = sanList[i + 1] || "";
       if (black) out.push(`${num}. ${white} ${black}`);
       else out.push(`${num}. ${white}`);
       num++;
     }
-    return out.join(' ');
+    return out.join(" ");
   }
 
-  checkGameOver(){
+  checkGameOver() {
     const g = this.game?.ch;
-    if (g && ((typeof g.isGameOver === 'function' && g.isGameOver()) || (typeof g.game_over === 'function' && g.game_over()))){
+    if (
+      g &&
+      ((typeof g.isGameOver === "function" && g.isGameOver()) ||
+        (typeof g.game_over === "function" && g.game_over()))
+    ) {
       this.gameOver = true;
       this.clock.pause();
       this.clockPanel.render?.();
@@ -663,72 +757,83 @@ export class App {
   }
 
   // === Check & Mate detection & celebration ===
-  isCheckNow(){
-    const lastSan = this.getSanHistory().slice(-1)[0] || '';
+  isCheckNow() {
+    const lastSan = this.getSanHistory().slice(-1)[0] || "";
     if (/\+$/.test(lastSan)) return true;
-    if (typeof this.game.isCheck === 'function' && this.game.isCheck()) return true;
-    if (typeof this.game.inCheck === 'function' && this.game.inCheck()) return true;
-    if (this.game.ch){
+    if (typeof this.game.isCheck === "function" && this.game.isCheck())
+      return true;
+    if (typeof this.game.inCheck === "function" && this.game.inCheck())
+      return true;
+    if (this.game.ch) {
       const ch = this.game.ch;
-      if (typeof ch.in_check === 'function' && ch.in_check()) return true;
-      if (typeof ch.isCheck === 'function' && ch.isCheck()) return true;
+      if (typeof ch.in_check === "function" && ch.in_check()) return true;
+      if (typeof ch.isCheck === "function" && ch.isCheck()) return true;
     }
     return false;
   }
 
-  isMateNow(){
+  isMateNow() {
     // 1) Library-agnostic: last SAN ends with '#'
-    const lastSan = this.getSanHistory().slice(-1)[0] || '';
+    const lastSan = this.getSanHistory().slice(-1)[0] || "";
     if (/#$/.test(lastSan)) return true;
 
     // 2) Wrapper APIs (various naming schemes)
-    if (typeof this.game.isCheckmate === 'function' && this.game.isCheckmate()) return true;
-    if (typeof this.game.inCheckmate === 'function' && this.game.inCheckmate()) return true;
+    if (typeof this.game.isCheckmate === "function" && this.game.isCheckmate())
+      return true;
+    if (typeof this.game.inCheckmate === "function" && this.game.inCheckmate())
+      return true;
 
     // 3) Underlying chess.js (if exposed)
     if (this.game.ch) {
       const ch = this.game.ch;
-      if (typeof ch.in_checkmate === 'function' && ch.in_checkmate()) return true;
-      if (typeof ch.isCheckmate === 'function' && ch.isCheckmate()) return true;
+      if (typeof ch.in_checkmate === "function" && ch.in_checkmate())
+        return true;
+      if (typeof ch.isCheckmate === "function" && ch.isCheckmate()) return true;
     }
 
     // 4) Fallback: game over but not draw (not perfect, but harmless)
-    if (typeof this.game.isGameOver === 'function' && typeof this.game.isDraw === 'function'){
+    if (
+      typeof this.game.isGameOver === "function" &&
+      typeof this.game.isDraw === "function"
+    ) {
       if (this.game.isGameOver() && !this.game.isDraw()) return true;
     }
-    if (this.game.ch){
+    if (this.game.ch) {
       const ch = this.game.ch;
-      if (typeof ch.game_over === 'function' && typeof ch.in_draw === 'function'){
+      if (
+        typeof ch.game_over === "function" &&
+        typeof ch.in_draw === "function"
+      ) {
         if (ch.game_over() && !ch.in_draw()) return true;
       }
     }
     return false;
   }
 
-  maybeCelebrate(){
+  maybeCelebrate() {
     if (this.inReview) return; // never in review
     const ply = this.getSanHistory().length;
-    if (this.isMateNow() && this.lastCelebrationPly !== ply){
+    if (this.isMateNow() && this.lastCelebrationPly !== ply) {
       this.lastCelebrationPly = ply;
       let kingSq = null;
       try {
         const turn = this.game.turn();
         const board = this.game.ch.board();
-        const files = 'abcdefgh';
+        const files = "abcdefgh";
         outer: for (let r = 0; r < 8; r++) {
           for (let f = 0; f < 8; f++) {
             const piece = board[r][f];
-            if (piece && piece.type === 'k' && piece.color === turn) {
+            if (piece && piece.type === "k" && piece.color === turn) {
               kingSq = files[f] + (8 - r);
               break outer;
             }
           }
         }
       } catch {}
-      this.sounds.play('airhorn');
+      this.sounds.play("airhorn");
       this.ui.celebrate?.(kingSq);
     }
   }
 }
 
-window.addEventListener('DOMContentLoaded', () => new App());
+window.addEventListener("DOMContentLoaded", () => new App());

--- a/chess-website-uml/public/src/puzzles/PuzzleService.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleService.js
@@ -1,32 +1,48 @@
 // Minimal service with tolerant mapping for Lichess endpoints and local packs.
-const LS_KEY = 'chesslab:puzzlePack';
+const LS_KEY = "chesslab:puzzlePack";
 
 export class PuzzleService {
-  constructor(){
+  constructor() {
     this.pack = [];
-    try { this.pack = JSON.parse(localStorage.getItem(LS_KEY) || '[]'); } catch {}
+    try {
+      this.pack = JSON.parse(localStorage.getItem(LS_KEY) || "[]");
+    } catch {}
   }
 
-  size(){ return this.pack.length|0; }
-  save(){ try { localStorage.setItem(LS_KEY, JSON.stringify(this.pack)); } catch {} }
+  size() {
+    return this.pack.length | 0;
+  }
+  save() {
+    try {
+      localStorage.setItem(LS_KEY, JSON.stringify(this.pack));
+    } catch {}
+  }
 
-  importCsvText(text, limit=3000){
+  importCsvText(text, limit = 3000) {
     // Expected headers from Lichess DB export: PuzzleId,FEN,Moves,Rating,...,Themes,GameUrl
     const lines = text.split(/\r?\n/).filter(Boolean);
     if (!lines.length) return 0;
-    const head = lines[0].split(',');
-    const idx = (k)=> head.indexOf(k);
-    const iId=idx('PuzzleId'), iFen=idx('FEN'), iMoves=idx('Moves'), iRating=idx('Rating'), iThemes=idx('Themes'), iGame=idx('GameUrl');
-    const out=[];
-    for (let i=1; i<lines.length && out.length<limit; i++){
+    const head = lines[0].split(",");
+    const idx = (k) => head.indexOf(k);
+    const iId = idx("PuzzleId"),
+      iFen = idx("FEN"),
+      iMoves = idx("Moves"),
+      iRating = idx("Rating"),
+      iThemes = idx("Themes"),
+      iGame = idx("GameUrl"),
+      iOpen = idx("OpeningTags") >= 0 ? idx("OpeningTags") : idx("Opening");
+    const out = [];
+    for (let i = 1; i < lines.length && out.length < limit; i++) {
       const cols = safeCsvSplit(lines[i], head.length);
       if (!cols.length) continue;
       out.push({
-        id: get(cols,iId), fen: get(cols,iFen),
-        moves: get(cols,iMoves),
-        rating: +(get(cols,iRating)||0),
-        themes: get(cols,iThemes)||'',
-        gameUrl: get(cols,iGame)||''
+        id: get(cols, iId),
+        fen: get(cols, iFen),
+        moves: get(cols, iMoves),
+        rating: +(get(cols, iRating) || 0),
+        themes: get(cols, iThemes) || "",
+        gameUrl: get(cols, iGame) || "",
+        opening: get(cols, iOpen) || "",
       });
     }
     this.pack = out;
@@ -34,65 +50,127 @@ export class PuzzleService {
     return out.length;
   }
 
-  async downloadPackJson(url){
-    const r = await fetch(url, { headers:{ 'accept':'application/json' } });
+  async downloadPackJson(url) {
+    const r = await fetch(url, { headers: { accept: "application/json" } });
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     const arr = await r.json();
-    if (!Array.isArray(arr)) throw new Error('JSON must be an array');
+    if (!Array.isArray(arr)) throw new Error("JSON must be an array");
     this.pack = arr;
     this.save();
     return this.pack.length;
   }
 
-  sample500(){
+  sample500() {
     if (!this.pack.length) return 0;
     const arr = [];
     const N = Math.min(500, this.pack.length);
-    for (let i=0; i<N; i++) arr.push(this.pack[(Math.random()*this.pack.length)|0]);
+    for (let i = 0; i < N; i++)
+      arr.push(this.pack[(Math.random() * this.pack.length) | 0]);
     this.pack = arr;
     this.save();
     return this.pack.length;
   }
 
-  randomFromPack({ theme='', min=0, max=4000 } = {}){
-    const t = (theme||'').toLowerCase();
-    const filtered = this.pack.filter(p => {
-      const okR = (+(p.rating||0) >= min) && (+(p.rating||0) <= max);
-      const okT = !t || String(p.themes||'').toLowerCase().includes(t);
-      return okR && okT;
+  randomFromPack({ theme = "", opening = "", min = 0, max = 4000 } = {}) {
+    const t = (theme || "").toLowerCase();
+    const o = (opening || "").toLowerCase();
+    const filtered = this.pack.filter((p) => {
+      const okR = +(p.rating || 0) >= min && +(p.rating || 0) <= max;
+      const okT =
+        !t ||
+        String(p.themes || "")
+          .toLowerCase()
+          .includes(t);
+      const okO =
+        !o ||
+        String(p.opening || "")
+          .toLowerCase()
+          .includes(o);
+      return okR && okT && okO;
     });
     if (!filtered.length) return null;
-    return filtered[(Math.random()*filtered.length)|0];
+    return filtered[(Math.random() * filtered.length) | 0];
   }
 
-  async fetchDaily(){
+  playlistFromPack({
+    theme = "",
+    opening = "",
+    min = 0,
+    max = 4000,
+    count = Infinity,
+  } = {}) {
+    const t = (theme || "").toLowerCase();
+    const o = (opening || "").toLowerCase();
+    const filtered = this.pack.filter((p) => {
+      const okR = +(p.rating || 0) >= min && +(p.rating || 0) <= max;
+      const okT =
+        !t ||
+        String(p.themes || "")
+          .toLowerCase()
+          .includes(t);
+      const okO =
+        !o ||
+        String(p.opening || "")
+          .toLowerCase()
+          .includes(o);
+      return okR && okT && okO;
+    });
+    if (!filtered.length) return [];
+    const arr = filtered.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = (Math.random() * (i + 1)) | 0;
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    if (Number.isFinite(count)) arr.length = Math.min(arr.length, count);
+    return arr;
+  }
+
+  async fetchDaily() {
     // No auth needed; returns JSON. We leave shaping to the adapter.
     // Accept header matters per docs.
-    const r = await fetch('https://lichess.org/api/puzzle/daily', { headers: { 'accept':'application/json' } });
+    const r = await fetch("https://lichess.org/api/puzzle/daily", {
+      headers: { accept: "application/json" },
+    });
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return await r.json();
   }
 
-  async fetchById(id){
-    const r = await fetch(`https://lichess.org/api/puzzle/${encodeURIComponent(id)}`, { headers: { 'accept':'application/json' } });
+  async fetchById(id) {
+    const r = await fetch(
+      `https://lichess.org/api/puzzle/${encodeURIComponent(id)}`,
+      { headers: { accept: "application/json" } },
+    );
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return await r.json();
   }
 }
 
 // --- helpers ---
-function get(a,i){ return (i>=0 && i<a.length) ? a[i] : ''; }
-function safeCsvSplit(line, expect){
+function get(a, i) {
+  return i >= 0 && i < a.length ? a[i] : "";
+}
+function safeCsvSplit(line, expect) {
   // naive CSV splitter covering quotes; adequate for Lichess dumps
-  const out=[]; let cur='', q=false;
-  for (let i=0;i<line.length;i++){
-    const ch=line[i];
-    if (ch==='\"'){ if (q && line[i+1]==='\"'){ cur+='\"'; i++; } else q=!q; continue; }
-    if (!q && ch===','){ out.push(cur); cur=''; continue; }
-    cur+=ch;
+  const out = [];
+  let cur = "",
+    q = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '\"') {
+      if (q && line[i + 1] === '\"') {
+        cur += '\"';
+        i++;
+      } else q = !q;
+      continue;
+    }
+    if (!q && ch === ",") {
+      out.push(cur);
+      cur = "";
+      continue;
+    }
+    cur += ch;
   }
   out.push(cur);
-  while(out.length<expect) out.push('');
+  while (out.length < expect) out.push("");
   return out;
 }
-

--- a/chess-website-uml/public/src/puzzles/PuzzleUI.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleUI.js
@@ -1,115 +1,188 @@
-import { Chess } from '../vendor/chess.mjs';
-import { adaptLichessPuzzle } from './PuzzleModel.js';
+import { Chess } from "../vendor/chess.mjs";
+import { adaptLichessPuzzle } from "./PuzzleModel.js";
 
 // Small helper: bind only if the element exists
-function on(el, type, fn){ if (el) el.addEventListener(type, fn); }
+function on(el, type, fn) {
+  if (el) el.addEventListener(type, fn);
+}
 
 export class PuzzleUI {
-  constructor({ game, ui, service, dom, onStateChanged, onMove, onPuzzleLoad }) {
+  constructor({
+    game,
+    ui,
+    service,
+    dom,
+    onStateChanged,
+    onMove,
+    onPuzzleLoad,
+  }) {
     this.game = game;
     this.ui = ui;
     this.svc = service;
     this.dom = dom || {};
-    this.onStateChanged = onStateChanged || (()=>{});
-    this.onMove = onMove || (()=>{});
-    this.onPuzzleLoad = onPuzzleLoad || (()=>{});
+    this.onStateChanged = onStateChanged || (() => {});
+    this.onMove = onMove || (() => {});
+    this.onPuzzleLoad = onPuzzleLoad || (() => {});
 
     this.current = null;
     this.index = 0;
+    this.playlist = [];
+    this.playIndex = -1;
 
     this.bindDom();
     this.updatePackInfo();
   }
 
-  show(flag){ if (this.dom?.panel) this.dom.panel.style.display = flag ? '' : 'none'; }
-  updatePackInfo(){
-    if (!this.dom?.packInfo) return;
-    this.dom.packInfo.textContent = this.svc?.size?.() ? `Local pack: ${this.svc.size()} puzzles` : 'No local pack.';
+  show(flag) {
+    if (this.dom?.panel) this.dom.panel.style.display = flag ? "" : "none";
   }
-  resetProgress(){
-    this.index=0;
-    if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent='';
+  updatePackInfo() {
+    if (!this.dom?.packInfo) return;
+    this.dom.packInfo.textContent = this.svc?.size?.()
+      ? `Local pack: ${this.svc.size()} puzzles`
+      : "No local pack.";
+  }
+  resetProgress() {
+    this.index = 0;
+    if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent = "";
   }
 
-  bindDom(){
+  bindDom() {
     const d = this.dom;
 
-    on(d.fetchDailyBtn, 'click', async () => {
-      try{ const p = await this.svc.fetchDaily(); this.loadConvertedPuzzle(p); }
-      catch(e){ alert('Daily fetch failed: '+e.message); }
+    on(d.fetchDailyBtn, "click", async () => {
+      try {
+        const p = await this.svc.fetchDaily();
+        this.loadConvertedPuzzle(p);
+      } catch (e) {
+        alert("Daily fetch failed: " + e.message);
+      }
     });
 
-    on(d.loadByIdBtn, 'click', async () => {
-      const id = (d.puzzleIdInput?.value||'').trim();
-      if (!id) { alert('Enter a puzzle ID'); return; }
-      try{ const p = await this.svc.fetchById(id); this.loadConvertedPuzzle(p); }
-      catch(e){ alert('ID fetch failed: '+e.message); }
+    on(d.loadByIdBtn, "click", async () => {
+      const id = (d.puzzleIdInput?.value || "").trim();
+      if (!id) {
+        alert("Enter a puzzle ID");
+        return;
+      }
+      try {
+        const p = await this.svc.fetchById(id);
+        this.loadConvertedPuzzle(p);
+      } catch (e) {
+        alert("ID fetch failed: " + e.message);
+      }
     });
 
-    on(d.importCsvBtn, 'click', () => d.importCsvFile?.click());
-    on(d.importCsvFile, 'change', async (ev) => {
-      const file = ev?.target?.files?.[0]; if (!file) return;
+    on(d.importCsvBtn, "click", () => d.importCsvFile?.click());
+    on(d.importCsvFile, "change", async (ev) => {
+      const file = ev?.target?.files?.[0];
+      if (!file) return;
       const text = await file.text();
       const n = this.svc.importCsvText(text, 3000);
       this.updatePackInfo();
       alert(`Imported ${n} puzzles.`);
     });
 
-    on(d.downloadPackBtn, 'click', async () => {
-      try{
-        const url = (d.packUrlInput?.value||'').trim();
-        if (!url) { alert('Enter a pack URL'); return; }
+    on(d.downloadPackBtn, "click", async () => {
+      try {
+        const url = (d.packUrlInput?.value || "").trim();
+        if (!url) {
+          alert("Enter a pack URL");
+          return;
+        }
         const text = await (await fetch(url)).text();
         const n = this.svc.importCsvText(text, 10000);
         this.updatePackInfo();
         alert(`Imported ${n} puzzles from URL.`);
-      }catch(e){ alert('Download failed: '+e.message); }
+      } catch (e) {
+        alert("Download failed: " + e.message);
+      }
     });
 
-    on(d.demoPackBtn, 'click', () => {
-      this.svc.pack = DEMO_PACK.slice(); this.svc.save?.(); this.updatePackInfo();
+    on(d.demoPackBtn, "click", () => {
+      this.svc.pack = DEMO_PACK.slice();
+      this.svc.save?.();
+      this.updatePackInfo();
       alert(`Loaded demo pack: ${this.svc.size()} puzzles.`);
     });
 
-    on(d.sample500Btn, 'click', () => {
-      const n = this.svc.sample500(); this.updatePackInfo(); alert(`Pack size is now ${n}.`);
+    on(d.sample500Btn, "click", () => {
+      const n = this.svc.sample500();
+      this.updatePackInfo();
+      alert(`Pack size is now ${n}.`);
     });
 
-    on(d.randomFromPackBtn, 'click', async () => {
-      if (!this.svc.size()){ alert('No local pack. Import or download first.'); return; }
-      const p = this.svc.randomFromPack({
-        theme: d.themeFilter?.value,
-        min: parseInt(d.minRating?.value||'0',10),
-        max: parseInt(d.maxRating?.value||'4000',10)
-      });
-      if (!p){ alert('No puzzles match your filter.'); return; }
-      try{ this.loadConvertedPuzzle(await adaptOrIdentity(p)); }
-      catch(e){ alert('Failed to load puzzle: '+e.message); }
-    });
+    on(d.randomFromPackBtn, "click", () => this.startPlaylist());
 
-    on(d.nextPuzzleBtn, 'click', () => this.loadBuiltinRandom());
-    on(d.hintBtn, 'click', () => this.hint());
+    on(d.nextPuzzleBtn, "click", () => this.nextInPlaylist());
+    on(d.hintBtn, "click", () => this.hint());
   }
 
-  loadBuiltinRandom(){
-    const p = BUILTIN_PUZZLES[Math.floor(Math.random()*BUILTIN_PUZZLES.length)];
-    this.current = { id:p.id, themes:p.themes, fen:p.fen, solutionSan: p.solution.slice() };
+  loadBuiltinRandom() {
+    const p =
+      BUILTIN_PUZZLES[Math.floor(Math.random() * BUILTIN_PUZZLES.length)];
+    this.current = {
+      id: p.id,
+      themes: p.themes,
+      fen: p.fen,
+      solutionSan: p.solution.slice(),
+    };
     this.index = 0;
     this.applyCurrent(true);
   }
 
-  async loadConvertedPuzzle(p){
-    try{
+  async startPlaylist() {
+    if (!this.svc.size()) {
+      alert("No local pack. Import or download first.");
+      return;
+    }
+    const d = this.dom;
+    const list = this.svc.playlistFromPack({
+      theme: d.themeFilter?.value,
+      opening: d.openingFilter?.value,
+      min: parseInt(d.minRating?.value || "0", 10),
+      max: parseInt(d.maxRating?.value || "4000", 10),
+    });
+    if (!list.length) {
+      alert("No puzzles match your filter.");
+      return;
+    }
+    this.playlist = list;
+    this.playIndex = 0;
+    try {
+      await this.loadConvertedPuzzle(await adaptOrIdentity(this.playlist[0]));
+    } catch (e) {
+      alert("Failed to load puzzle: " + e.message);
+    }
+  }
+
+  async nextInPlaylist() {
+    if (!this.playlist.length) {
+      this.loadBuiltinRandom();
+      return;
+    }
+    this.playIndex = (this.playIndex + 1) % this.playlist.length;
+    try {
+      await this.loadConvertedPuzzle(
+        await adaptOrIdentity(this.playlist[this.playIndex]),
+      );
+    } catch (e) {
+      alert("Failed to load puzzle: " + e.message);
+    }
+  }
+
+  async loadConvertedPuzzle(p) {
+    try {
       const c = await adaptOrIdentity(p);
       this.current = c;
       this.index = 0;
       this.applyCurrent(true);
-    }catch(e){
-      alert('Failed to convert puzzle: ' + e.message);
+    } catch (e) {
+      alert("Failed to convert puzzle: " + e.message);
     }
   }
 
-  applyCurrent(center=false){
+  applyCurrent(center = false) {
     if (!this.current) return;
     // Ensure the side to move in puzzle FEN is loaded
     this.game.load?.(this.current.fen);
@@ -117,11 +190,13 @@ export class PuzzleUI {
     this.ui.clearArrow?.();
 
     // show puzzle meta
-    if (this.dom?.puzzleInfo){
-      const themeText = this.current.themes ? ` — <span class="muted">${this.current.themes}</span>` : '';
-      this.dom.puzzleInfo.innerHTML = `<b>Puzzle</b> #${this.current.id || 'local'}${themeText}`;
+    if (this.dom?.puzzleInfo) {
+      const themeText = this.current.themes
+        ? ` — <span class="muted">${this.current.themes}</span>`
+        : "";
+      this.dom.puzzleInfo.innerHTML = `<b>Puzzle</b> #${this.current.id || "local"}${themeText}`;
     }
-    if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent = '';
+    if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent = "";
 
     this.onPuzzleLoad(this.game.turn?.());
     this.onStateChanged();
@@ -129,28 +204,31 @@ export class PuzzleUI {
   }
 
   // Called by App when user makes a move in puzzle mode
-  handleUserMove(mv){
+  handleUserMove(mv) {
     const sanNeeded = this.current?.solutionSan?.[this.index];
     if (!sanNeeded) return false;
 
     // Compare user move with expected SAN
     const userSan = mv?.san;
-    if (userSan === sanNeeded){
+    if (userSan === sanNeeded) {
       // Good move
       this.index++;
-      if (this.dom?.puzzleStatus) this.dom.puzzleStatus.innerHTML = `<span style="color:#39d98a">Correct!</span>`;
-      if (this.index >= (this.current?.solutionSan?.length||0)) {
-        if (this.dom?.puzzleStatus) this.dom.puzzleStatus.innerHTML = `<span style="color:#39d98a">Solved 🎉</span>`;
+      if (this.dom?.puzzleStatus)
+        this.dom.puzzleStatus.innerHTML = `<span style="color:#39d98a">Correct!</span>`;
+      if (this.index >= (this.current?.solutionSan?.length || 0)) {
+        if (this.dom?.puzzleStatus)
+          this.dom.puzzleStatus.innerHTML = `<span style="color:#39d98a">Solved 🎉</span>`;
         return true;
       } else {
         // Auto play the opponent reply (next SAN)
         const reply = this.current.solutionSan[this.index];
         const applied = this.game.moveSan(reply);
-        if (applied){
+        if (applied) {
           this.onMove(applied);
           this.index++;
           this.onStateChanged();
-          if (this.dom?.puzzleStatus) this.dom.puzzleStatus.innerHTML = `<span style="color:#8aa0b6">Your move…</span>`;
+          if (this.dom?.puzzleStatus)
+            this.dom.puzzleStatus.innerHTML = `<span style="color:#8aa0b6">Your move…</span>`;
           return true;
         } else {
           // If reply cannot be played, just wait for next user move
@@ -158,24 +236,25 @@ export class PuzzleUI {
         }
       }
     } else {
-      if (this.dom?.puzzleStatus) this.dom.puzzleStatus.innerHTML = `<span style="color:#ff6b6b">Try again.</span>`;
+      if (this.dom?.puzzleStatus)
+        this.dom.puzzleStatus.innerHTML = `<span style="color:#ff6b6b">Try again.</span>`;
       this.game.undo();
       return false;
     }
   }
 
-  hint(){
+  hint() {
     const san = this.current?.solutionSan?.[this.index];
     if (!san) return;
     const tmp = new Chess(this.game.fen());
     const m = tmp.move(san);
-    if (m) this.ui.drawArrowUci?.(m.from + m.to + (m.promotion||''));
+    if (m) this.ui.drawArrowUci?.(m.from + m.to + (m.promotion || ""));
   }
 }
 
 // Prefer native lichess format, else pass-through
-export async function adaptOrIdentity(p){
-  if (!p) throw new Error('No puzzle data');
+export async function adaptOrIdentity(p) {
+  if (!p) throw new Error("No puzzle data");
 
   // Prefer native lichess format and let the adapter report issues
   if (p.puzzle || p.id || p.PuzzleId) {
@@ -183,20 +262,55 @@ export async function adaptOrIdentity(p){
   }
 
   // fallback: expect { id, fen, solution: [SAN...] }
-  if (!p.fen) throw new Error('Puzzle missing FEN');
-  return { id: p.id||'local', fen: p.fen, themes: p.themes || p.thema || '', solutionSan: (p.solution||[]).slice() };
+  if (!p.fen) throw new Error("Puzzle missing FEN");
+  return {
+    id: p.id || "local",
+    fen: p.fen,
+    themes: p.themes || p.thema || "",
+    solutionSan: (p.solution || []).slice(),
+  };
 }
 
 // Tiny demo pack to prime the UI if users don’t provide one
 const DEMO_PACK = [
-  { id:'demo-1', fen:'r2q1rk1/pp1b1ppp/2n1pn2/2bp4/3P4/2PBPN2/PP3PPP/R1BQ1RK1 w - - 0 1', themes:'QGD', solution:['dxc5','e5','e4'] },
-  { id:'demo-2', fen:'rnbqk2r/pppp1ppp/5n2/4p3/1bP5/2N2N2/PP1PPPPP/R1BQKB1R w KQkq - 2 4', themes:'Sicilian/Caro', solution:['Nxe5','O-O','g3'] },
-  { id:'demo-3', fen:'r2q1rk1/pp2bppp/2n1pn2/2bp4/3P4/2P1PN2/PP1N1PPP/R1BQ1RK1 w - - 0 1', themes:'QGD', solution:['dxc5','e5','e4'] },
+  {
+    id: "demo-1",
+    fen: "r2q1rk1/pp1b1ppp/2n1pn2/2bp4/3P4/2PBPN2/PP3PPP/R1BQ1RK1 w - - 0 1",
+    themes: "QGD",
+    solution: ["dxc5", "e5", "e4"],
+  },
+  {
+    id: "demo-2",
+    fen: "rnbqk2r/pppp1ppp/5n2/4p3/1bP5/2N2N2/PP1PPPPP/R1BQKB1R w KQkq - 2 4",
+    themes: "Sicilian/Caro",
+    solution: ["Nxe5", "O-O", "g3"],
+  },
+  {
+    id: "demo-3",
+    fen: "r2q1rk1/pp2bppp/2n1pn2/2bp4/3P4/2P1PN2/PP1N1PPP/R1BQ1RK1 w - - 0 1",
+    themes: "QGD",
+    solution: ["dxc5", "e5", "e4"],
+  },
 ];
 
 // A few built-in puzzles if there’s nothing else around
 const BUILTIN_PUZZLES = [
-  { id:'b1', themes:'Mate in 1', fen:'6k1/5ppp/8/8/8/8/5PPP/6KQ w - - 0 1', solution:['Qa8#'] },
-  { id:'b2', themes:'Fork', fen:'r1bqkbnr/pppp1ppp/2n5/4p3/3P4/5N2/PPP1PPPP/RNBQKB1R w KQkq - 2 3', solution:['d5','Nd4'] },
-  { id:'b3', themes:'Skewer', fen:'3r2k1/pp3ppp/8/8/8/8/PP3PPP/3R2K1 w - - 0 1', solution:['Rxd8#'] },
+  {
+    id: "b1",
+    themes: "Mate in 1",
+    fen: "6k1/5ppp/8/8/8/8/5PPP/6KQ w - - 0 1",
+    solution: ["Qa8#"],
+  },
+  {
+    id: "b2",
+    themes: "Fork",
+    fen: "r1bqkbnr/pppp1ppp/2n5/4p3/3P4/5N2/PPP1PPPP/RNBQKB1R w KQkq - 2 3",
+    solution: ["d5", "Nd4"],
+  },
+  {
+    id: "b3",
+    themes: "Skewer",
+    fen: "3r2k1/pp3ppp/8/8/8/8/PP3PPP/3R2K1 w - - 0 1",
+    solution: ["Rxd8#"],
+  },
 ];

--- a/tests/puzzleService.test.js
+++ b/tests/puzzleService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleService } from "../chess-website-uml/public/src/puzzles/PuzzleService.js";
+
+test("playlistFromPack filters by theme, opening and rating", () => {
+  const svc = new PuzzleService();
+  svc.pack = [
+    { id: "a", rating: 900, themes: "fork", opening: "Sicilian" },
+    { id: "b", rating: 1200, themes: "mate", opening: "French" },
+    { id: "c", rating: 1150, themes: "fork", opening: "Sicilian" },
+  ];
+  const list = svc.playlistFromPack({
+    theme: "fork",
+    opening: "Sicilian",
+    min: 1000,
+    max: 1300,
+  });
+  assert.equal(list.length, 1);
+  assert.equal(list[0].id, "c");
+});


### PR DESCRIPTION
## Summary
- allow CSV imports to capture opening tags and support filtering by opening
- add playlist support to Puzzle UI for looping through random puzzles matching filters
- include tests for playlist filtering logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f0294cf4832e88230f6ac7f3f460