### PR TITLE
refactor: embed puzzle controls around board

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -479,6 +479,25 @@
       <div class="stack">
         <!-- BOARD FIRST -->
         <div class="board-area">
+          <div id="puzzleTop" style="display: none">
+            <div class="row">
+              <label>Opening</label>
+              <select id="openingFilter" style="flex: 1"></select>
+            </div>
+            <div class="row">
+              <label>Difficulty</label>
+              <input
+                type="range"
+                id="difficultyRange"
+                min="1"
+                max="10"
+                value="5"
+              />
+              <span class="muted" id="difficultyLabel">Medium</span>
+            </div>
+            <div class="muted" id="puzzleInfo">—</div>
+            <div class="status" id="puzzleStatus"></div>
+          </div>
           <div class="player-clock black" id="clockBlack">05:00</div>
           <div class="board-wrap">
             <div class="evalbar" id="evalbar">
@@ -508,6 +527,12 @@
             </div>
           </div>
           <div class="player-clock white" id="clockWhite">05:00</div>
+          <div class="row" id="puzzleBottom" style="display: none">
+            <button id="fetchDaily">Daily</button>
+            <button id="startPuzzle">New</button>
+            <button id="nextPuzzle">Next</button>
+            <button id="puzzleHint">Hint</button>
+          </div>
         </div>
 
         <!-- CONTROLS UNDER THE BOARD -->
@@ -623,32 +648,6 @@
         </div>
 
         <!-- Puzzles -->
-        <div class="card" id="puzzlePanel" style="display: none">
-          <h3>Puzzles</h3>
-          <div class="row">
-            <button id="fetchDaily">Daily</button>
-            <button id="startPuzzle">New</button>
-            <button id="nextPuzzle">Next</button>
-            <button id="puzzleHint">Hint</button>
-          </div>
-          <div class="row">
-            <label>Opening</label>
-            <select id="openingFilter" style="flex: 1"></select>
-          </div>
-          <div class="row">
-            <label>Difficulty</label>
-            <input
-              type="range"
-              id="difficultyRange"
-              min="1"
-              max="10"
-              value="5"
-            />
-            <span class="muted" id="difficultyLabel">Medium</span>
-          </div>
-          <div class="muted" id="puzzleInfo">—</div>
-          <div class="status" id="puzzleStatus"></div>
-        </div>
       </div>
       <footer class="site-footer">
         <p>

--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -103,7 +103,10 @@ export class App {
       ui: this.ui,
       service: this.puzzleService,
       dom: {
-        panel: qs("#puzzlePanel"),
+        panelTop: qs("#puzzleTop"),
+        panelBottom: qs("#puzzleBottom"),
+        clockBlack: qs("#clockBlack"),
+        clockWhite: qs("#clockWhite"),
         fetchDailyBtn: qs("#fetchDaily"),
         startPuzzleBtn: qs("#startPuzzle"),
         nextPuzzleBtn: qs("#nextPuzzle"),
@@ -228,6 +231,7 @@ export class App {
         }
       }
       this.refreshAll();
+      this.applyOrientation();
       this.updateModeButtonStyles();
     });
 
@@ -305,7 +309,12 @@ export class App {
   applyOrientation() {
     const side = this.sideSel.value;
     this.ui.setOrientation(side);
-    this.boardArea.classList.toggle("flipped", side === "black");
+    const mode = this.modeSel?.value || "play";
+    if (mode === "puzzle") {
+      this.boardArea.classList.remove("flipped");
+    } else {
+      this.boardArea.classList.toggle("flipped", side === "black");
+    }
   }
 
   startNewGame() {

--- a/chess-website-uml/public/src/puzzles/PuzzleUI.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleUI.js
@@ -43,7 +43,14 @@ export class PuzzleUI {
   }
 
   show(flag) {
-    if (this.dom?.panel) this.dom.panel.style.display = flag ? "" : "none";
+    if (this.dom?.panelTop)
+      this.dom.panelTop.style.display = flag ? "" : "none";
+    if (this.dom?.panelBottom)
+      this.dom.panelBottom.style.display = flag ? "" : "none";
+    if (this.dom?.clockBlack)
+      this.dom.clockBlack.style.display = flag ? "none" : "";
+    if (this.dom?.clockWhite)
+      this.dom.clockWhite.style.display = flag ? "none" : "";
   }
   resetProgress() {
     this.index = 0;


### PR DESCRIPTION
## Summary
- move puzzle filters and info above the board and action buttons below it
- hide clocks during puzzles and keep board orientation from flipping

## Testing
- `npx prettier --write chess-website-uml/public/index.html chess-website-uml/public/src/app/App.js chess-website-uml/public/src/puzzles/PuzzleUI.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a200dc1118832e927bf1054375bfee