### PR TITLE
feat: shrink board by 5%

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -122,12 +122,12 @@
         border-radius: 12px;
         padding: 10px;
         margin-inline: auto;
-        width: 92vw;
-        max-width: 660px;
+        width: calc(92vw * 0.95);
+        max-width: calc(660px * 0.95);
       }
       @media (min-width: 980px) {
         .board-wrap {
-          width: 40vw;
+          width: calc(40vw * 0.95);
           max-width: none;
         }
       }


### PR DESCRIPTION
## Summary
- reduce chessboard container width by 5% for all screen sizes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20321444c832eabf993648ee30614