### PR TITLE
Fix puzzle state reset and board orientation

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -124,6 +124,8 @@ export class App {
       onMove: (mv) => this.playMoveSound(mv),
       onPuzzleLoad: (turn) => {
         this.sideSel.value = turn === "w" ? "white" : "black";
+        this.gameOver = false;
+        this.applyOrientation();
         this.updateSwitchButtonText();
       },
     });

--- a/tests/puzzleOrientation.test.js
+++ b/tests/puzzleOrientation.test.js
@@ -1,37 +1,60 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { PuzzleUI } from '../chess-website-uml/public/src/puzzles/PuzzleUI.js';
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleUI } from "../chess-website-uml/public/src/puzzles/PuzzleUI.js";
 
 // Ensure puzzle loading orients board for side to move
 
-test('loadConvertedPuzzle flips orientation', async () => {
+test("loadConvertedPuzzle flips orientation", async () => {
   const game = {
-    fenStr: '',
-    load(f){ this.fenStr = f; },
-    fen(){ return this.fenStr; },
-    turn(){ return this.fenStr.split(' ')[1]; },
-    moveSan(){ return {}; },
-    undo(){}
+    fenStr: "",
+    load(f) {
+      this.fenStr = f;
+    },
+    fen() {
+      return this.fenStr;
+    },
+    turn() {
+      return this.fenStr.split(" ")[1];
+    },
+    moveSan() {
+      return {};
+    },
+    undo() {},
   };
   let oriented = null;
-  const app = { sideSel: { value: 'white' } };
+  const app = {
+    sideSel: { value: "white" },
+    gameOver: true,
+    applyOrientation() {
+      ui.setOrientation(this.sideSel.value);
+    },
+  };
   const ui = {
     clearArrow() {},
     resizeOverlay() {},
     drawArrowUci() {},
-    setOrientation(side){ oriented = side; }
+    setOrientation(side) {
+      oriented = side;
+    },
   };
   const puzzles = new PuzzleUI({
     game,
     ui,
     service: {},
     dom: {},
-    onStateChanged: () => ui.setOrientation(app.sideSel.value),
+    onStateChanged: () => {},
     onMove: () => {},
-    onPuzzleLoad: (turn) => { app.sideSel.value = (turn === 'w') ? 'white' : 'black'; }
+    onPuzzleLoad: (turn) => {
+      app.sideSel.value = turn === "w" ? "white" : "black";
+      app.gameOver = false;
+      app.applyOrientation();
+    },
   });
 
-  await puzzles.loadConvertedPuzzle({ puzzle:{ id:'p1', fen:'8/8/8/8/8/8/8/k6K b - - 0 1', moves:'a1b1' } });
-  assert.equal(app.sideSel.value, 'black');
-  assert.equal(oriented, 'black');
+  await puzzles.loadConvertedPuzzle({
+    puzzle: { id: "p1", fen: "8/8/8/8/8/8/8/k6K b - - 0 1", moves: "a1b1" },
+  });
+  assert.equal(app.sideSel.value, "black");
+  assert.equal(oriented, "black");
+  assert.equal(app.gameOver, false);
 });


### PR DESCRIPTION
## Summary
- Ensure puzzle loading resets `gameOver` flag and re-applies board orientation
- Extend puzzle orientation test to verify game over state reset

## Testing
- `npx prettier --write chess-website-uml/public/src/app/App.js tests/puzzleOrientation.test.js`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2037a25bc832ea37d95488fe2ac74