### PR TITLE
Swap puzzle control panels

### DIFF
--- a/chess-website-uml/public/index.html
+++ b/chess-website-uml/public/index.html
@@ -479,24 +479,11 @@
       <div class="stack">
         <!-- BOARD FIRST -->
         <div class="board-area">
-          <div id="puzzleTop" style="display: none">
-            <div class="row">
-              <label>Opening</label>
-              <select id="openingFilter" style="flex: 1"></select>
-            </div>
-            <div class="row">
-              <label>Difficulty</label>
-              <input
-                type="range"
-                id="difficultyRange"
-                min="1"
-                max="10"
-                value="5"
-              />
-              <span class="muted" id="difficultyLabel">Medium</span>
-            </div>
-            <div class="muted" id="puzzleInfo">—</div>
-            <div class="status" id="puzzleStatus"></div>
+          <div class="row" id="puzzleBottom" style="display: none">
+            <button id="fetchDaily">Daily</button>
+            <button id="startPuzzle">New</button>
+            <button id="nextPuzzle">Next</button>
+            <button id="puzzleHint">Hint</button>
           </div>
           <div class="player-clock black" id="clockBlack">05:00</div>
           <div class="board-wrap">
@@ -527,11 +514,24 @@
             </div>
           </div>
           <div class="player-clock white" id="clockWhite">05:00</div>
-          <div class="row" id="puzzleBottom" style="display: none">
-            <button id="fetchDaily">Daily</button>
-            <button id="startPuzzle">New</button>
-            <button id="nextPuzzle">Next</button>
-            <button id="puzzleHint">Hint</button>
+          <div id="puzzleTop" style="display: none">
+            <div class="muted" id="puzzleInfo">—</div>
+            <div class="status" id="puzzleStatus"></div>
+            <div class="row">
+              <label>Opening</label>
+              <select id="openingFilter" style="flex: 1"></select>
+            </div>
+            <div class="row">
+              <label>Difficulty</label>
+              <input
+                type="range"
+                id="difficultyRange"
+                min="1"
+                max="10"
+                value="5"
+              />
+              <span class="muted" id="difficultyLabel">Medium</span>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Show puzzle action buttons above the board
- Move puzzle filters below the board and display metadata first

## Testing
- `npx prettier --write chess-website-uml/public/index.html`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20601d584832ea17dab59ca9ffc97