### PR TITLE
Autoplay first move for CSV puzzles

### DIFF
--- a/tests/puzzleOrientation.test.js
+++ b/tests/puzzleOrientation.test.js
@@ -1,26 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { PuzzleUI } from "../chess-website-uml/public/src/puzzles/PuzzleUI.js";
+import { Game } from "../chess-website-uml/public/src/core/Game.js";
 
 // Ensure puzzle loading orients board for side to move
 
 test("loadConvertedPuzzle flips orientation", async () => {
-  const game = {
-    fenStr: "",
-    load(f) {
-      this.fenStr = f;
-    },
-    fen() {
-      return this.fenStr;
-    },
-    turn() {
-      return this.fenStr.split(" ")[1];
-    },
-    moveSan() {
-      return {};
-    },
-    undo() {},
-  };
+  const game = new Game();
   let oriented = null;
   const app = {
     sideSel: { value: "white" },
@@ -53,8 +39,9 @@ test("loadConvertedPuzzle flips orientation", async () => {
 
   await puzzles.loadConvertedPuzzle({
     puzzle: { id: "p1", fen: "8/8/8/8/8/8/8/k6K b - - 0 1", moves: "a1b1" },
+    autoplayFirst: true,
   });
-  assert.equal(app.sideSel.value, "black");
-  assert.equal(oriented, "black");
+  assert.equal(app.sideSel.value, "white");
+  assert.equal(oriented, "white");
   assert.equal(app.gameOver, false);
 });

--- a/tests/puzzleValidation.test.js
+++ b/tests/puzzleValidation.test.js
@@ -1,12 +1,12 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { PuzzleUI } from '../chess-website-uml/public/src/puzzles/PuzzleUI.js';
-import { Game } from '../chess-website-uml/public/src/core/Game.js';
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleUI } from "../chess-website-uml/public/src/puzzles/PuzzleUI.js";
+import { Game } from "../chess-website-uml/public/src/core/Game.js";
 
 const PUZZLE = {
-  id: 'test',
-  fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2',
-  solutionSan: ['d5', 'exd5']
+  id: "test",
+  fen: "r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+  solutionSan: ["d5", "exd5"],
 };
 
 function createPuzzleUI() {
@@ -18,29 +18,31 @@ function createPuzzleUI() {
     service: {},
     dom: {},
     onStateChanged: () => {},
-    onMove: () => {}
+    onMove: () => {},
   });
   puzzles.current = { ...PUZZLE };
+  puzzles.autoplayFirst = true;
   puzzles.index = 0;
   puzzles.applyCurrent();
   return { puzzles, game };
 }
 
-test('handleUserMove accepts correct moves and advances puzzle', () => {
+test("handleUserMove accepts correct moves and advances puzzle", () => {
   const { puzzles, game } = createPuzzleUI();
-  const mv = game.move({ from: 'd7', to: 'd5' });
+  const mv = game.move({ from: "e4", to: "d5" });
   assert.ok(mv);
   const res = puzzles.handleUserMove(mv);
   assert.equal(res, true);
   assert.equal(puzzles.index, 2); // both moves played
 });
 
-test('handleUserMove rejects incorrect moves and reverts position', () => {
+test("handleUserMove rejects incorrect moves and reverts position", () => {
   const { puzzles, game } = createPuzzleUI();
-  const mv = game.move({ from: 'g8', to: 'f6' }); // Nf6 is wrong
+  const startFen = game.fen();
+  const mv = game.move({ from: "c2", to: "c3" }); // c3 is wrong
   assert.ok(mv);
   const res = puzzles.handleUserMove(mv);
   assert.equal(res, false);
-  assert.equal(puzzles.index, 0);
-  assert.equal(game.fen(), PUZZLE.fen);
+  assert.equal(puzzles.index, 1);
+  assert.equal(game.fen(), startFen);
 });


### PR DESCRIPTION
## Summary
- autoplay the first solution move for puzzles loaded from CSV so it's the player's turn
- orient board based on turn after autoplay
- adjust puzzle tests for new behavior

## Testing
- `npx prettier --write chess-website-uml/public/src/puzzles/PuzzleUI.js tests/puzzleValidation.test.js tests/puzzleOrientation.test.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20636f908832ea1213cdfae4bc1e8