### PR TITLE
Show side to move when puzzle loads

### DIFF
--- a/chess-website-uml/public/src/puzzles/PuzzleUI.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleUI.js
@@ -147,7 +147,11 @@ export class PuzzleUI {
         : "";
       this.dom.puzzleInfo.innerHTML = `<b>Puzzle</b> #${this.current.id || "local"}${rating}${opening}`;
     }
-    if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent = "";
+    if (this.dom?.puzzleStatus) {
+      const turn = this.game.turn?.();
+      const text = turn === "w" ? "White to move" : "Black to move";
+      this.dom.puzzleStatus.innerHTML = `<span style="color:#8aa0b6">${text}</span>`;
+    }
 
     this.onPuzzleLoad(this.game.turn?.());
     this.onStateChanged();


### PR DESCRIPTION
## Summary
- Display which side moves first when a puzzle is loaded

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2082a302c832e8bbc1bf0cb604fd2