### PR TITLE
Fix difficulty-based puzzle lazy loading

### DIFF
--- a/chess-website-uml/public/src/puzzles/PuzzleService.js
+++ b/chess-website-uml/public/src/puzzles/PuzzleService.js
@@ -42,10 +42,10 @@ export class PuzzleService {
       }
       return null;
     } else {
-      const fileIdx = Math.max(
-        1,
-        Math.min(37, Math.round((difficulty / 10) * 37)),
-      );
+      const target = (min + max) / 2;
+      const step = 2400 / 37;
+      const idx = Math.round((target - 400) / step) + 1;
+      const fileIdx = Math.max(1, Math.min(37, idx));
       const file = String(fileIdx).padStart(3, "0");
       const arr = await this.loadCsv(
         `./lib/lichess_puzzle_db/rating_sort/lichess_db_puzzle_sorted.${file}.csv`,


### PR DESCRIPTION
## Summary
- Correct rating file selection for non-opening puzzles to avoid empty results for valid filters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a209c8ea90832eb492b0898db70016