### PR TITLE
celebrate after puzzle solved

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -813,6 +813,11 @@ export class App {
   maybeCelebrate() {
     if (this.inReview) return; // never in review
     const ply = this.getSanHistory().length;
+    const solvedPuzzle =
+      this.modeSel.value === "puzzle" &&
+      this.puzzles?.current &&
+      this.puzzles.index >= (this.puzzles.current.solutionSan?.length || 0);
+
     if (this.isMateNow() && this.lastCelebrationPly !== ply) {
       this.lastCelebrationPly = ply;
       let kingSq = null;
@@ -832,6 +837,10 @@ export class App {
       } catch {}
       this.sounds.play("airhorn");
       this.ui.celebrate?.(kingSq);
+    } else if (solvedPuzzle && this.lastCelebrationPly !== ply) {
+      this.lastCelebrationPly = ply;
+      this.sounds.play("airhorn");
+      this.ui.celebrate?.();
     }
   }
 }

--- a/tests/puzzleCelebration.test.js
+++ b/tests/puzzleCelebration.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// minimal DOM stubs for importing App
+globalThis.window = { addEventListener() {} };
+globalThis.document = {
+  querySelector() {
+    return null;
+  },
+  getElementById() {
+    return null;
+  },
+  createElement() {
+    return {
+      setAttribute() {},
+      appendChild() {},
+      style: {},
+      textContent: "",
+      id: "",
+    };
+  },
+  head: { appendChild() {} },
+};
+
+const { App } = await import("../chess-website-uml/public/src/app/App.js");
+
+test("celebrates when puzzle solved without mate", () => {
+  const app = Object.create(App.prototype);
+  app.inReview = false;
+  app.lastCelebrationPly = -1;
+  app.getSanHistory = () => ["e4"];
+  app.isMateNow = () => false;
+  app.modeSel = { value: "puzzle" };
+  app.puzzles = { current: { solutionSan: ["e4"] }, index: 1 };
+  app.sounds = {
+    played: null,
+    play(n) {
+      this.played = n;
+    },
+  };
+  app.ui = {
+    celebrated: false,
+    square: undefined,
+    celebrate(sq) {
+      this.celebrated = true;
+      this.square = sq;
+    },
+  };
+
+  App.prototype.maybeCelebrate.call(app);
+
+  assert.equal(app.sounds.played, "airhorn");
+  assert.equal(app.ui.celebrated, true);
+  assert.equal(app.ui.square, undefined);
+  assert.equal(app.lastCelebrationPly, 1);
+});


### PR DESCRIPTION
## Summary
- Fire confetti when a puzzle is solved even if the final move isn't mate
- Add regression test covering puzzle celebration without checkmate

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20dbb4108832e8a7ef0ed79ce79df