### PR TITLE
Expand celebration effect and soften sound

### DIFF
--- a/chess-website-uml/public/src/ui/BoardUI.js
+++ b/chess-website-uml/public/src/ui/BoardUI.js
@@ -96,7 +96,7 @@ const BLACK_GLYPH = { k: "♚", q: "♛", r: "♜", b: "♝", n: "♞", p: "♟"
     .confetti-root { position:absolute; inset:0; overflow:visible; pointer-events:none; z-index:5; }
     .confetti-piece {
       position:absolute;
-      width:8px; height:8px;
+      width:12px; height:12px;
       opacity:.95;
       transform: translate(-50%, -50%);
       animation: confetti-explode 1.2s ease-out forwards;
@@ -773,10 +773,7 @@ export class BoardUI {
     if (!from || !to || from === to || !this.dragTargets.has(to)) return;
 
     const piece = this.getPieceAt(from);
-    if (
-      piece?.type === "p" &&
-      (to[1] === "8" || to[1] === "1")
-    ) {
+    if (piece?.type === "p" && (to[1] === "8" || to[1] === "1")) {
       this.promptPromotion(from, to, piece.color);
     } else {
       const ok = this.onUserMove({ from, to });
@@ -838,10 +835,7 @@ export class BoardUI {
       // Move if selected and target is legal
       if (this.selected && this.dragTargets.has(sq)) {
         const pieceSel = this.getPieceAt(this.selected);
-        if (
-          pieceSel?.type === "p" &&
-          (sq[1] === "8" || sq[1] === "1")
-        ) {
+        if (pieceSel?.type === "p" && (sq[1] === "8" || sq[1] === "1")) {
           this.promptPromotion(this.selected, sq, pieceSel.color);
         } else {
           const ok = this.onUserMove({ from: this.selected, to: sq });
@@ -963,7 +957,7 @@ export class BoardUI {
       ? this.squareCenterPx(square)
       : { x: this.boardEl.clientWidth / 2, y: this.boardEl.clientHeight / 2 };
     const colors = ["#e74c3c", "#f1c40f", "#2ecc71", "#3498db", "#9b59b6"];
-    for (let i = 0; i < 120; i++) {
+    for (let i = 0; i < 200; i++) {
       const piece = document.createElement("div");
       piece.className = "confetti-piece";
       piece.style.left = `${origin.x}px`;
@@ -971,7 +965,7 @@ export class BoardUI {
       piece.style.backgroundColor =
         colors[Math.floor(Math.random() * colors.length)];
       const angle = Math.random() * Math.PI * 2;
-      const distance = 80 + Math.random() * 120;
+      const distance = 120 + Math.random() * 160;
       piece.style.setProperty("--dx", `${Math.cos(angle) * distance}px`);
       piece.style.setProperty("--dy", `${Math.sin(angle) * distance}px`);
       piece.style.animationDelay = (Math.random() * 0.2).toFixed(2) + "s";

--- a/chess-website-uml/public/src/util/Sounds.js
+++ b/chess-website-uml/public/src/util/Sounds.js
@@ -5,7 +5,9 @@ export class Sounds {
 
   play(name) {
     try {
-      const ctx = this.ctx || (this.ctx = new (window.AudioContext || window.webkitAudioContext)());
+      const ctx =
+        this.ctx ||
+        (this.ctx = new (window.AudioContext || window.webkitAudioContext)());
       const now = ctx.currentTime;
 
       // slight variation each play
@@ -16,7 +18,13 @@ export class Sounds {
         capture: { filter: 1000, osc: 160, dur: 0.2 },
         check: { filter: 1700, osc: 400, dur: 0.25 },
         checkmate: { filter: 1800, osc: 600, dur: 0.3 },
-        airhorn: { filter: 800, osc: 150, dur: 1.2, gain: 0.25, type: 'square' }
+        airhorn: {
+          filter: 1200,
+          osc: 300,
+          dur: 0.8,
+          gain: 0.12,
+          type: "triangle",
+        },
       };
       const p = profiles[name] || profiles.move;
 
@@ -36,7 +44,7 @@ export class Sounds {
       noise.buffer = buffer;
 
       const filter = ctx.createBiquadFilter();
-      filter.type = 'lowpass';
+      filter.type = "lowpass";
       filter.frequency.value = p.filter * detune;
       filter.Q.value = 0.5;
       noise.connect(filter);
@@ -44,7 +52,7 @@ export class Sounds {
 
       // subtle tone or horn
       const osc = ctx.createOscillator();
-      osc.type = p.type || 'sine';
+      osc.type = p.type || "sine";
       osc.frequency.value = p.osc * detune;
       osc.connect(gain);
 


### PR DESCRIPTION
## Summary
- increase confetti piece size, count, and spread for a more noticeable celebration
- replace harsh airhorn with a softer triangle-wave tone at reduced volume

## Testing
- `npx prettier --write chess-website-uml/public/src/ui/BoardUI.js chess-website-uml/public/src/util/Sounds.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20f2ec92c832ea336c18aba361eb5