### PR TITLE
feat: enlarge king and queen pieces for clarity

### DIFF
--- a/chess-website-uml/public/src/ui/BoardUI.js
+++ b/chess-website-uml/public/src/ui/BoardUI.js
@@ -48,6 +48,13 @@ const BLACK_GLYPH = { k: "♚", q: "♛", r: "♜", b: "♝", n: "♞", p: "♟"
     .dragPiece.glyph.piece-b {
       font-size: calc(var(--cell) * 0.88);
     }
+    /* Make kings and queens larger for easier identification */
+    .sq .glyph.piece-k,
+    .dragPiece.glyph.piece-k,
+    .sq .glyph.piece-q,
+    .dragPiece.glyph.piece-q {
+      font-size: calc(var(--cell) * 0.94);
+    }
     /* Inverted outlines + fill color per side */
     .sq.pw .glyph { color: #fff; }       /* white piece: white fill */
     .sq.pb .glyph { color: #0b0b0b; }    /* black piece: black fill */


### PR DESCRIPTION
## Summary
- increase king and queen glyph sizes for improved visibility

## Testing
- `npx prettier --write chess-website-uml/public/src/ui/BoardUI.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a210fa681c832ea49432269c423c62