### PR TITLE
Thin white outline on black chess pieces

### DIFF
--- a/chess-website-uml/public/src/ui/BoardUI.js
+++ b/chess-website-uml/public/src/ui/BoardUI.js
@@ -29,17 +29,22 @@ const BLACK_GLYPH = { k: "♚", q: "♛", r: "♜", b: "♝", n: "♞", p: "♟"
       line-height: 1;
       font-size: calc(var(--cell) * 0.82);
       /* Outline color is provided via --glyph-outline (set by piece color) */
-      -webkit-text-stroke: max(0.6px, calc(var(--cell) * 0.01)) var(--glyph-outline, #000);
+      --outline: var(
+        --glyph-outline-w,
+        max(0.6px, calc(var(--cell) * 0.01))
+      );
+      -webkit-text-stroke: var(--outline) var(--glyph-outline, #000);
       /* Fallback outline using layered text-shadows (thinner than before) */
       text-shadow:
-        0  0.6px  var(--glyph-outline, #000),
-        0.6px 0   var(--glyph-outline, #000),
-        0 -0.6px  var(--glyph-outline, #000),
-       -0.6px 0   var(--glyph-outline, #000),
-        0.6px 0.6px var(--glyph-outline, #000),
-        0.6px -0.6px var(--glyph-outline, #000),
-       -0.6px 0.6px var(--glyph-outline, #000),
-       -0.6px -0.6px var(--glyph-outline, #000);
+        0 var(--outline) var(--glyph-outline, #000),
+        var(--outline) 0 var(--glyph-outline, #000),
+        0 calc(var(--outline) * -1) var(--glyph-outline, #000),
+        calc(var(--outline) * -1) 0 var(--glyph-outline, #000),
+        var(--outline) var(--outline) var(--glyph-outline, #000),
+        var(--outline) calc(var(--outline) * -1) var(--glyph-outline, #000),
+        calc(var(--outline) * -1) var(--outline) var(--glyph-outline, #000),
+        calc(var(--outline) * -1) calc(var(--outline) * -1)
+          var(--glyph-outline, #000);
       pointer-events: none;
       user-select: none;
     }
@@ -59,11 +64,18 @@ const BLACK_GLYPH = { k: "♚", q: "♛", r: "♜", b: "♝", n: "♞", p: "♟"
     .sq.pw .glyph { color: #fff; }       /* white piece: white fill */
     .sq.pb .glyph { color: #0b0b0b; }    /* black piece: black fill */
     .sq.pw { --glyph-outline: #000; }    /* white piece gets black outline */
-    .sq.pb { --glyph-outline: #fff; }    /* black piece gets white outline */
+    .sq.pb {
+      --glyph-outline: #fff;
+      --glyph-outline-w: max(0.3px, calc(var(--cell) * 0.005));
+    }    /* black piece gets white outline */
 
     /* Drag ghost adopts same rules by adding .pw/.pb on the ghost element */
     .dragPiece.glyph.pw { --glyph-outline: #000; color: #fff; }
-    .dragPiece.glyph.pb { --glyph-outline: #fff; color: #0b0b0b; }
+    .dragPiece.glyph.pb {
+      --glyph-outline: #fff;
+      --glyph-outline-w: max(0.3px, calc(var(--cell) * 0.005));
+      color: #0b0b0b;
+    }
 
     /* Legal move dots */
     .sq .dot {


### PR DESCRIPTION
## Summary
- Use CSS variable to allow custom outline width for glyphs
- Reduce white outline width on black pieces and drag ghost to half

## Testing
- `npx prettier --write chess-website-uml/public/src/ui/BoardUI.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a271929a58832ea4d3fcea1efa8b89