### PR TITLE
Add staged hints for puzzles

### DIFF
--- a/chess-website-uml/public/src/app/App.js
+++ b/chess-website-uml/public/src/app/App.js
@@ -3,7 +3,7 @@ import { Clock } from "../core/Clock.js";
 import { BoardUI } from "../ui/BoardUI.js";
 import { WorkerEngine } from "../engine/WorkerEngine.js";
 import { PuzzleService } from "../puzzles/PuzzleService.js";
-import { PuzzleUI } from "../puzzles/PuzzleUI.js";
+import { PuzzleUI } from "../ui/PuzzleUI.js";
 import { ClockPanel } from "../ui/ClockPanel.js";
 import { detectOpening } from "../engine/Openings.js";
 import { Sounds } from "../util/Sounds.js";

--- a/tests/adaptOrIdentity.test.js
+++ b/tests/adaptOrIdentity.test.js
@@ -1,22 +1,22 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { adaptOrIdentity } from '../chess-website-uml/public/src/puzzles/PuzzleUI.js';
-import { Chess } from '../chess-website-uml/public/src/vendor/chess.mjs';
+import test from "node:test";
+import assert from "node:assert/strict";
+import { adaptOrIdentity } from "../chess-website-uml/public/src/ui/PuzzleUI.js";
+import { Chess } from "../chess-website-uml/public/src/vendor/chess.mjs";
 
 const SAMPLE = {
   puzzle: {
-    id: 'p123',
-    fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2',
+    id: "p123",
+    fen: "r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
     rating: 1500,
-    themes: ['fork'],
-    solution: ['d7d5', 'e4d5', 'd8d5', 'b1c3']
+    themes: ["fork"],
+    solution: ["d7d5", "e4d5", "d8d5", "b1c3"],
   },
-  game: { id: 'ABCDEFG' }
+  game: { id: "ABCDEFG" },
 };
 
-const EXPECTED_SAN = ['d5', 'exd5', 'Qxd5', 'Nc3'];
+const EXPECTED_SAN = ["d5", "exd5", "Qxd5", "Nc3"];
 
-test('adaptOrIdentity adapts Lichess daily puzzle', async () => {
+test("adaptOrIdentity adapts Lichess daily puzzle", async () => {
   const res = await adaptOrIdentity(SAMPLE);
   assert.equal(res.fen, SAMPLE.puzzle.fen);
   assert.deepEqual(res.solutionSan, EXPECTED_SAN);
@@ -24,15 +24,15 @@ test('adaptOrIdentity adapts Lichess daily puzzle', async () => {
 
 const SAMPLE_STR = {
   puzzle: {
-    id: 'p124',
-    fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2',
+    id: "p124",
+    fen: "r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
     rating: 1500,
-    themes: ['fork'],
-    solution: 'd7d5 e4d5 d8d5 b1c3'
-  }
+    themes: ["fork"],
+    solution: "d7d5 e4d5 d8d5 b1c3",
+  },
 };
 
-test('adaptOrIdentity handles solution strings', async () => {
+test("adaptOrIdentity handles solution strings", async () => {
   const res = await adaptOrIdentity(SAMPLE_STR);
   assert.equal(res.fen, SAMPLE_STR.puzzle.fen);
   assert.deepEqual(res.solutionSan, EXPECTED_SAN);
@@ -40,38 +40,38 @@ test('adaptOrIdentity handles solution strings', async () => {
 
 const SAMPLE_GAME_FEN = {
   puzzle: {
-    id: 'p125',
+    id: "p125",
     rating: 1500,
-    themes: ['fork'],
-    solution: ['d7d5', 'e4d5']
+    themes: ["fork"],
+    solution: ["d7d5", "e4d5"],
   },
   game: {
-    id: 'HIJKLMN',
-    fen: 'r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2'
-  }
+    id: "HIJKLMN",
+    fen: "r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+  },
 };
 
-test('adaptOrIdentity uses game FEN when puzzle FEN missing', async () => {
+test("adaptOrIdentity uses game FEN when puzzle FEN missing", async () => {
   const res = await adaptOrIdentity(SAMPLE_GAME_FEN);
   assert.equal(res.fen, SAMPLE_GAME_FEN.game.fen);
-  assert.deepEqual(res.solutionSan, ['d5', 'exd5']);
+  assert.deepEqual(res.solutionSan, ["d5", "exd5"]);
 });
 
 const SAMPLE_PGN_FEN = {
   game: {
-    id: '06iacbDF',
-    pgn: 'e4 d5 exd5 Qxd5 Nc3 Qd8 d4 e5 Nf3 exd4 Nxd4 c5 Nb3 Qxd1+ Nxd1 c4 Bxc4 Bg4 O-O Bb4 Ne3 Be6 c3 Bc5 Re1 Bb6 Bxe6 fxe6 Nf5 Kf7 Nd6+ Kg6 Nxb7 Ne7 Rxe6+ Kf7 Re4 Rd8 Bg5 Rd7 N7c5 Bxc5 Nxc5 Rc7 b4 Nbc6 b5 Nd8 Rae1 Ng6 Na4 h6 Bf4 Nxf4 Rxf4+ Kg6 c4 Nb7 Re5 Rd8 h4 Na5 c5 a6 Re6+ Kh5 Rxa6 g5 Rff6 Nc4 Rxh6+ Kg4 hxg5 Re7 g6 Re1+ Kh2 Rdd1 f3+ Kg5 Rh3 Ne3 g7',
+    id: "06iacbDF",
+    pgn: "e4 d5 exd5 Qxd5 Nc3 Qd8 d4 e5 Nf3 exd4 Nxd4 c5 Nb3 Qxd1+ Nxd1 c4 Bxc4 Bg4 O-O Bb4 Ne3 Be6 c3 Bc5 Re1 Bb6 Bxe6 fxe6 Nf5 Kf7 Nd6+ Kg6 Nxb7 Ne7 Rxe6+ Kf7 Re4 Rd8 Bg5 Rd7 N7c5 Bxc5 Nxc5 Rc7 b4 Nbc6 b5 Nd8 Rae1 Ng6 Na4 h6 Bf4 Nxf4 Rxf4+ Kg6 c4 Nb7 Re5 Rd8 h4 Na5 c5 a6 Re6+ Kh5 Rxa6 g5 Rff6 Nc4 Rxh6+ Kg4 hxg5 Re7 g6 Re1+ Kh2 Rdd1 f3+ Kg5 Rh3 Ne3 g7",
   },
   puzzle: {
-    id: 'Q9cVx',
+    id: "Q9cVx",
     rating: 1820,
-    solution: ['e1h1', 'h2g3', 'e3f5', 'g3f2', 'd1d2'],
-    themes: ['endgame', 'long', 'mateIn3'],
+    solution: ["e1h1", "h2g3", "e3f5", "g3f2", "d1d2"],
+    themes: ["endgame", "long", "mateIn3"],
     initialPly: 82,
   },
 };
 
-test('adaptOrIdentity derives FEN from PGN and initial ply', async () => {
+test("adaptOrIdentity derives FEN from PGN and initial ply", async () => {
   const res = await adaptOrIdentity(SAMPLE_PGN_FEN);
 
   // Expected FEN by replaying the PGN up to the initial ply
@@ -94,7 +94,11 @@ test('adaptOrIdentity derives FEN from PGN and initial ply', async () => {
   for (const uci of SAMPLE_PGN_FEN.puzzle.solution) {
     const m = uci.match(/^([a-h][1-8])([a-h][1-8])([qrbn])?$/);
     if (!m) break;
-    const step = tmp.move({ from: m[1], to: m[2], promotion: m[3] || undefined });
+    const step = tmp.move({
+      from: m[1],
+      to: m[2],
+      promotion: m[3] || undefined,
+    });
     if (!step) break;
     expectedSan.push(step.san);
   }

--- a/tests/puzzleHint.test.js
+++ b/tests/puzzleHint.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleUI } from "../chess-website-uml/public/src/ui/PuzzleUI.js";
+import { Game } from "../chess-website-uml/public/src/core/Game.js";
+
+const PUZZLE = {
+  id: "test",
+  fen: "r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+  solutionSan: ["d5", "exd5"],
+};
+
+function createPuzzleUI() {
+  const game = new Game();
+  const highlights = new Map();
+  const ui = {
+    arrow: null,
+    clearArrow() {
+      this.arrow = null;
+    },
+    drawArrowUci(uci) {
+      this.arrow = uci;
+    },
+    squareEl(sq) {
+      if (!highlights.has(sq)) highlights.set(sq, new Set());
+      const set = highlights.get(sq);
+      return {
+        classList: {
+          add: (cls) => set.add(cls),
+          remove: (cls) => set.delete(cls),
+        },
+      };
+    },
+  };
+  const puzzles = new PuzzleUI({ game, ui, service: {}, dom: {} });
+  puzzles.current = { ...PUZZLE };
+  puzzles.index = 0;
+  puzzles.applyCurrent();
+  return { puzzles, ui, highlights };
+}
+
+test("hint highlights piece then shows move", () => {
+  const { puzzles, ui, highlights } = createPuzzleUI();
+  puzzles.hint();
+  assert.equal(ui.arrow, null);
+  assert.ok(highlights.get("d7")?.has("hl-from"));
+  puzzles.hint();
+  assert.equal(ui.arrow, "d7d5");
+  assert.ok(!highlights.get("d7")?.has("hl-from"));
+});

--- a/tests/puzzleOrientation.test.js
+++ b/tests/puzzleOrientation.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { PuzzleUI } from "../chess-website-uml/public/src/puzzles/PuzzleUI.js";
+import { PuzzleUI } from "../chess-website-uml/public/src/ui/PuzzleUI.js";
 import { Game } from "../chess-website-uml/public/src/core/Game.js";
 
 // Ensure puzzle loading orients board for side to move

--- a/tests/puzzleValidation.test.js
+++ b/tests/puzzleValidation.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { PuzzleUI } from "../chess-website-uml/public/src/puzzles/PuzzleUI.js";
+import { PuzzleUI } from "../chess-website-uml/public/src/ui/PuzzleUI.js";
 import { Game } from "../chess-website-uml/public/src/core/Game.js";
 
 const PUZZLE = {


### PR DESCRIPTION
## Summary
- Highlight puzzle piece on first hint press and show full move on second
- Move PuzzleUI into `src/ui` and update imports to match new hierarchy
- Test staged hint behavior

## Testing
- `npx prettier --write chess-website-uml/public/src/ui/PuzzleUI.js chess-website-uml/public/src/app/App.js tests/puzzleValidation.test.js tests/puzzleHint.test.js tests/puzzleOrientation.test.js tests/adaptOrIdentity.test.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a271cbeb34832ebcf530b2f442fd6e