### PR TITLE
Add theme filtering for puzzles

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,6 +521,14 @@
               <select id="openingFilter" style="flex: 1"></select>
             </div>
             <div class="row">
+              <label>Theme</label>
+              <input
+                id="themeFilter"
+                placeholder="e.g., fork"
+                style="flex: 1"
+              />
+            </div>
+            <div class="row">
               <label>Difficulty</label>
               <input
                 type="range"

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -111,6 +111,7 @@ export class App {
         newPuzzleBtn: qs("#newPuzzle"),
         hintBtn: qs("#puzzleHint"),
         openingSel: qs("#openingFilter"),
+        themeInput: qs("#themeFilter"),
         difficultyRange: qs("#difficultyRange"),
         difficultyLabel: qs("#difficultyLabel"),
         puzzleInfo: qs("#puzzleInfo"),

--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -102,7 +102,13 @@ export class PuzzleUI {
     try {
       const diff = parseInt(this.dom.difficultyRange?.value || "5", 10);
       const opening = this.dom.openingSel?.value || "";
-      const p = await this.svc.randomFiltered({ difficulty: diff, opening });
+      const themeStr = this.dom.themeInput?.value || "";
+      const themes = themeStr.split(/[,\s]+/).filter(Boolean);
+      const p = await this.svc.randomFiltered({
+        difficulty: diff,
+        opening,
+        themes,
+      });
       if (!p) {
         alert("No puzzle matches your filter.");
         return;

--- a/tests/puzzleThemeFilter.test.js
+++ b/tests/puzzleThemeFilter.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleService } from "../chess-website-uml/public/src/puzzles/PuzzleService.js";
+
+test("randomFiltered filters by themes", async () => {
+  const svc = new PuzzleService();
+  svc.loadCsv = async () => [
+    { id: "1", rating: 500, themes: "fork", openingTags: "" },
+    { id: "2", rating: 500, themes: "pin", openingTags: "" },
+  ];
+  const res1 = await svc.randomFiltered({ difficulty: 1, themes: ["fork"] });
+  assert.equal(res1.id, "1");
+  const res2 = await svc.randomFiltered({ difficulty: 1, themes: ["pin"] });
+  assert.equal(res2.id, "2");
+  const res3 = await svc.randomFiltered({ difficulty: 1, themes: ["skewer"] });
+  assert.equal(res3, null);
+});


### PR DESCRIPTION
## Summary
- Support filtering puzzles by theme in the puzzle service
- Wire theme filter through UI and application
- Add tests covering theme filtering

## Testing
- `npx prettier --write index.html src/app/App.js src/puzzles/PuzzleService.js src/puzzles/PuzzleUI.js tests/puzzleThemeFilter.test.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2778d8dac832e97939731432da737