### PR TITLE
fix: stabilize puzzle difficulty slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,6 +344,17 @@
       .row label {
         min-width: 80px;
       }
+      #difficultyRow {
+        position: relative;
+      }
+      #difficultyLabel {
+        position: absolute;
+        left: 100%;
+        margin-left: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+        white-space: nowrap;
+      }
       .button-row {
         justify-content: center;
       }
@@ -524,7 +535,7 @@
               <label>Theme</label>
               <select id="themeFilter" style="flex: 1"></select>
             </div>
-            <div class="row">
+            <div class="row" id="difficultyRow">
               <label>Difficulty</label>
               <input
                 type="range"


### PR DESCRIPTION
## Summary
- keep puzzle panel from shifting when moving the difficulty slider by absolutely positioning the label text

## Testing
- `npx prettier --write index.html`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27d5a53cc832ea9e2092b655f820f