### PR TITLE
Allow puzzles without difficulty filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,9 @@
         transform: translateY(-50%);
         white-space: nowrap;
       }
+      #difficultyRange:disabled {
+        opacity: 0.5;
+      }
       .button-row {
         justify-content: center;
       }
@@ -536,7 +539,10 @@
               <select id="themeFilter" style="flex: 1"></select>
             </div>
             <div class="row" id="difficultyRow">
-              <label>Difficulty</label>
+              <label>
+                <input type="checkbox" id="difficultyFilter" checked />
+                Difficulty
+              </label>
               <input
                 type="range"
                 id="difficultyRange"

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -112,6 +112,7 @@ export class App {
         hintBtn: qs("#puzzleHint"),
         openingSel: qs("#openingFilter"),
         themeSel: qs("#themeFilter"),
+        difficultyFilter: qs("#difficultyFilter"),
         difficultyRange: qs("#difficultyRange"),
         difficultyLabel: qs("#difficultyLabel"),
         puzzleInfo: qs("#puzzleInfo"),

--- a/tests/puzzleNoDifficulty.test.js
+++ b/tests/puzzleNoDifficulty.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleService } from "../chess-website-uml/public/src/puzzles/PuzzleService.js";
+
+test("randomFiltered works without difficulty filter", async () => {
+  const svc = new PuzzleService();
+  svc.loadCsv = async () => [
+    { id: "1", rating: 500, themes: "", openingTags: "" },
+    { id: "2", rating: 2500, themes: "", openingTags: "" },
+  ];
+  const origRandom = Math.random;
+  Math.random = () => 0; // deterministic
+  const res = await svc.randomFiltered({});
+  Math.random = origRandom;
+  assert.equal(res.id, "1");
+});


### PR DESCRIPTION
## Summary
- Add checkbox to toggle puzzle difficulty filtering and disable slider when unchecked
- Skip rating bounds when filter disabled to fetch any puzzle
- Cover optional difficulty filtering with a new test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a281b3ca00832eaebb338f777506da