### PR TITLE
fix: prevent mobile side-scroll from difficulty description

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,6 +358,19 @@
       #difficultyRange:disabled {
         opacity: 0.5;
       }
+      @media (max-width: 600px) {
+        #difficultyRow {
+          position: static;
+        }
+        #difficultyLabel {
+          position: static;
+          margin-left: 0;
+          margin-top: 8px;
+          transform: none;
+          white-space: normal;
+          flex-basis: 100%;
+        }
+      }
       .button-row {
         justify-content: center;
       }


### PR DESCRIPTION
## Summary
- place difficulty description below slider on small screens to avoid horizontal overflow

## Testing
- `npx prettier --write index.html`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f1a59e5c832e8683990c509eeafd