### PR TITLE
fix: force text glyphs for pawns on iOS

### DIFF
--- a/src/ui/BoardUI.js
+++ b/src/ui/BoardUI.js
@@ -28,6 +28,7 @@ const BLACK_GLYPH = { k: "♚", q: "♛", r: "♜", b: "♝", n: "♞", p: "♟"
       display: inline-block;
       line-height: 1;
       font-size: calc(var(--cell) * 0.82);
+      font-variant-emoji: text;
       --glyph-outline-width: max(0.6px, calc(var(--cell) * 0.01));
       /* Outline color is provided via --glyph-outline (set by piece color) */
       -webkit-text-stroke: var(--glyph-outline-width) var(--glyph-outline, #000);


### PR DESCRIPTION
## Summary
- prevent pawn emoji rendering in iOS Safari by forcing text glyphs

## Testing
- `npx prettier --write chess-website-uml/public/src/ui/BoardUI.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f169395c832eb2f411267df50042