### PR TITLE
fix: ensure pawn glyph renders as text on iOS

### DIFF
--- a/src/ui/BoardUI.js
+++ b/src/ui/BoardUI.js
@@ -10,7 +10,15 @@
 const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
 
 // Use the *black* glyph codepoints for BOTH sides (solid shapes)
-const BLACK_GLYPH = { k: "♚", q: "♛", r: "♜", b: "♝", n: "♞", p: "♟" };
+// Append U+FE0E (text presentation) to avoid emoji glyphs on iOS Safari
+const BLACK_GLYPH = {
+  k: "♚\uFE0E",
+  q: "♛\uFE0E",
+  r: "♜\uFE0E",
+  b: "♝\uFE0E",
+  n: "♞\uFE0E",
+  p: "♟\uFE0E",
+};
 
 // ---------------- CSS injection ----------------
 (function injectStyle() {


### PR DESCRIPTION
## Summary
- append text-variation selector to chess piece glyphs to avoid iOS Safari emoji rendering

## Testing
- `npx prettier --write src/ui/BoardUI.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f169395c832eb2f411267df50042