### PR TITLE
Reset puzzle celebration state on new puzzle

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -123,12 +123,7 @@ export class App {
         this.refreshAll();
       },
       onMove: (mv) => this.playMoveSound(mv),
-      onPuzzleLoad: (turn) => {
-        this.sideSel.value = turn === "w" ? "white" : "black";
-        this.gameOver = false;
-        this.applyOrientation();
-        this.updateSwitchButtonText();
-      },
+      onPuzzleLoad: this.handlePuzzleLoad.bind(this),
     });
 
     // --- REVIEW MODE state ---
@@ -356,6 +351,15 @@ export class App {
   updateSwitchButtonText() {
     const next = this.sideSel.value === "white" ? "black" : "white";
     this.switchBtn.textContent = `Switch to ${next} and restart`;
+  }
+
+  handlePuzzleLoad(turn) {
+    this.sideSel.value = turn === "w" ? "white" : "black";
+    this.gameOver = false;
+    this.applyOrientation();
+    this.updateSwitchButtonText();
+    this.lastCelebrationPly = -1;
+    this.ui.stopCelebration?.();
   }
 
   setMode(mode) {

--- a/tests/puzzleCelebration.test.js
+++ b/tests/puzzleCelebration.test.js
@@ -54,3 +54,31 @@ test("celebrates when puzzle solved without mate", () => {
   assert.equal(app.ui.square, undefined);
   assert.equal(app.lastCelebrationPly, 1);
 });
+
+test("resets celebration state when puzzle loads", () => {
+  const app = Object.create(App.prototype);
+  app.sideSel = { value: "white" };
+  app.gameOver = true;
+  app.applyOrientation = () => {
+    app.oriented = true;
+  };
+  app.updateSwitchButtonText = () => {
+    app.switchTextUpdated = true;
+  };
+  app.ui = {
+    stopped: false,
+    stopCelebration() {
+      this.stopped = true;
+    },
+  };
+  app.lastCelebrationPly = 3;
+
+  App.prototype.handlePuzzleLoad.call(app, "b");
+
+  assert.equal(app.sideSel.value, "black");
+  assert.equal(app.gameOver, false);
+  assert.equal(app.lastCelebrationPly, -1);
+  assert.equal(app.ui.stopped, true);
+  assert.equal(app.oriented, true);
+  assert.equal(app.switchTextUpdated, true);
+});


### PR DESCRIPTION
## Summary
- Reset celebration tracking and stop confetti when a new puzzle loads
- Add regression test for puzzle load celebration reset

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a30f3bac00832e891ec4063bd84c3e