### PR TITLE
feat: prompt for new puzzle after solving

### DIFF
--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -278,8 +278,7 @@ export class PuzzleUI {
       if (this.dom?.puzzleStatus)
         this.dom.puzzleStatus.innerHTML = `<span style="color:#39d98a">Correct!</span>`;
       if (this.index >= (this.current?.solutionSan?.length || 0)) {
-        if (this.dom?.puzzleStatus)
-          this.dom.puzzleStatus.innerHTML = `<span style="color:#39d98a">Solved 🎉</span>`;
+        this.promptNewPuzzle();
         return true;
       } else {
         const reply = this.current.solutionSan[this.index];
@@ -301,6 +300,15 @@ export class PuzzleUI {
       this.game.undo();
       return false;
     }
+  }
+
+  promptNewPuzzle() {
+    if (!this.dom?.puzzleStatus) return;
+    this.dom.puzzleStatus.innerHTML =
+      `<span style="color:#39d98a">Solved 🎉</span>` +
+      '<button id="nextPuzzle" style="margin-left:8px">New Puzzle?</button>';
+    const btn = this.dom.puzzleStatus.querySelector("#nextPuzzle");
+    on(btn, "click", () => this.loadFilteredRandom());
   }
 
   hint() {

--- a/tests/puzzleNextPrompt.test.js
+++ b/tests/puzzleNextPrompt.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleUI } from "../chess-website-uml/public/src/puzzles/PuzzleUI.js";
+import { Game } from "../chess-website-uml/public/src/core/Game.js";
+
+test("prompts for new puzzle when solved", () => {
+  const game = new Game();
+  let clickHandler;
+  const puzzleStatus = {
+    innerHTML: "",
+    querySelector() {
+      return {
+        addEventListener(type, fn) {
+          clickHandler = fn;
+        },
+      };
+    },
+  };
+  const puzzles = new PuzzleUI({
+    game,
+    ui: { clearArrow() {}, drawArrowUci() {} },
+    service: {},
+    dom: { puzzleStatus },
+  });
+  puzzles.current = { solutionSan: ["e4"] };
+  puzzles.index = 0;
+
+  let nextCalled = false;
+  puzzles.loadFilteredRandom = () => {
+    nextCalled = true;
+  };
+
+  const mv = game.move({ from: "e2", to: "e4" });
+  assert.ok(mv);
+  const res = puzzles.handleUserMove(mv);
+  assert.equal(res, true);
+  assert.match(puzzleStatus.innerHTML, /Solved/);
+  assert.match(puzzleStatus.innerHTML, /button/);
+
+  clickHandler();
+  assert.equal(nextCalled, true);
+});


### PR DESCRIPTION
## Summary
- Show a "New Puzzle?" prompt once a puzzle is solved and load another puzzle on click
- Cover puzzle completion prompt with a unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a30f6cafec832eaca25bbf3117b099