### PR TITLE
Move puzzle metadata below status

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,8 +541,8 @@
           </div>
           <div class="player-clock white" id="clockWhite">05:00</div>
           <div id="puzzleTop" style="display: none">
-            <div class="muted" id="puzzleInfo">—</div>
             <div class="status" id="puzzleStatus"></div>
+            <div class="muted" id="puzzleInfo">—</div>
             <div class="row">
               <label>Opening</label>
               <select id="openingFilter" style="flex: 1"></select>


### PR DESCRIPTION
## Summary
- Reorder puzzle panel layout so status text appears above metadata

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a30fb640dc832e85d318b02f5f344b