### PR TITLE
Remove daily puzzle button and label daily puzzle

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,6 @@
         <!-- BOARD FIRST -->
         <div class="board-area">
           <div class="row" id="puzzleBottom" style="display: none">
-            <button id="fetchDaily">Daily</button>
             <button id="newPuzzle">New Puzzle</button>
             <button id="puzzleHint">Hint</button>
           </div>

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -107,7 +107,6 @@ export class App {
         panelBottom: qs("#puzzleBottom"),
         clockBlack: qs("#clockBlack"),
         clockWhite: qs("#clockWhite"),
-        fetchDailyBtn: qs("#fetchDaily"),
         newPuzzleBtn: qs("#newPuzzle"),
         hintBtn: qs("#puzzleHint"),
         openingSel: qs("#openingFilter"),
@@ -229,7 +228,7 @@ export class App {
         this.clockPanel.pause();
         try {
           const p = await this.puzzleService.fetchDaily();
-          await this.puzzles.loadConvertedPuzzle(p);
+          await this.puzzles.loadConvertedPuzzle({ ...p, daily: true });
         } catch (e) {
           this.engineStatus.textContent = "Daily puzzle fetch failed";
         }

--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -159,16 +159,6 @@ export class PuzzleUI {
 
   bindDom() {
     const d = this.dom;
-
-    on(d.fetchDailyBtn, "click", async () => {
-      try {
-        const p = await this.svc.fetchDaily();
-        this.loadConvertedPuzzle(p);
-      } catch (e) {
-        alert("Daily fetch failed: " + e.message);
-      }
-    });
-
     const loadFiltered = () => this.loadFilteredRandom();
     on(d.newPuzzleBtn, "click", loadFiltered);
     on(d.hintBtn, "click", () => this.hint());
@@ -218,7 +208,7 @@ export class PuzzleUI {
   async loadConvertedPuzzle(p) {
     try {
       const c = await adaptOrIdentity(p);
-      this.current = c;
+      this.current = { ...c, daily: p.daily };
       this.index = 0;
       this.autoplayFirst = !!p.autoplayFirst;
       this.applyCurrent(true);
@@ -246,7 +236,10 @@ export class PuzzleUI {
       const opening = this.current.opening
         ? ` — <span class="muted">${this.current.opening.replace(/_/g, " ")}</span>`
         : "";
-      this.dom.puzzleInfo.innerHTML = `<b>Puzzle</b> #${this.current.id || "local"}${rating}${opening}`;
+      const label = this.current.daily ? "Daily puzzle" : "Puzzle";
+      this.dom.puzzleInfo.innerHTML = `<b>${label}</b> #${
+        this.current.id || "local"
+      }${rating}${opening}`;
     }
     if (this.dom?.puzzleStatus) {
       const turn = this.game.turn?.();


### PR DESCRIPTION
## Summary
- Remove manual "Daily" puzzle button; daily puzzle loads automatically
- Fetch daily puzzle on mode switch and flag it as a daily puzzle
- Display "Daily puzzle" label in puzzle metadata

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3100c5988832eb7bcaa63842bc38e