### PR TITLE
Avoid repeating puzzles within a session

### DIFF
--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -106,6 +106,7 @@ export class PuzzleUI {
     this.autoplayFirst = false;
     this.hintStage = 0;
     this.hintSquare = null;
+    this.seenIds = new Set();
 
     this.bindDom();
     this.populateOpenings();
@@ -220,7 +221,11 @@ export class PuzzleUI {
       const opening = this.dom.openingSel?.value || "";
       const theme = this.dom.themeSel?.value || "";
       const themes = theme ? [theme] : [];
-      const opts = { opening, themes };
+      const opts = {
+        opening,
+        themes,
+        excludeIds: Array.from(this.seenIds),
+      };
       if (diffMin !== null) opts.difficultyMin = diffMin;
       if (diffMax !== null) opts.difficultyMax = diffMax;
       const p = await this.svc.randomFiltered(opts);
@@ -238,6 +243,7 @@ export class PuzzleUI {
     try {
       const c = await adaptOrIdentity(p);
       this.current = { ...c, daily: p.daily };
+      if (this.current.id) this.seenIds.add(this.current.id);
       this.index = 0;
       this.autoplayFirst = !!p.autoplayFirst;
       this.applyCurrent(true);

--- a/tests/puzzleExcludeIds.test.js
+++ b/tests/puzzleExcludeIds.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleService } from "../chess-website-uml/public/src/puzzles/PuzzleService.js";
+
+test("randomFiltered respects excludeIds", async () => {
+  const svc = new PuzzleService();
+  svc.loadCsv = async () => [
+    { id: "1", rating: 500, themes: "", openingTags: "" },
+    { id: "2", rating: 500, themes: "", openingTags: "" },
+  ];
+  const res = await svc.randomFiltered({
+    difficultyMin: 1,
+    difficultyMax: 1,
+    excludeIds: ["1"],
+  });
+  assert.equal(res.id, "2");
+});


### PR DESCRIPTION
## Summary
- Track IDs of puzzles seen in the current session
- Allow PuzzleService to exclude specified IDs when picking a random puzzle
- Add test ensuring exclusion behaves as expected

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a312c2f130832eb3633d63348e31cc