### PR TITLE
Limit difficulty slider fill to selected range

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,6 +366,7 @@
         width: 100%;
         pointer-events: none;
         background: none;
+        accent-color: var(--square-dark);
       }
       #difficultySlider input[type="range"]::-webkit-slider-thumb {
         pointer-events: all;


### PR DESCRIPTION
## Summary
- Keep difficulty slider track neutral and rely on blue overlay between pointers

## Testing
- `npx prettier --write index.html`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a32467267c832eb9cc8cd91eae7e04