### PR TITLE
Center puzzle completion prompt

### DIFF
--- a/css/controls.css
+++ b/css/controls.css
@@ -1,16 +1,57 @@
 /* Clocks and controls */
-.clockRow{display:grid; grid-template-columns: 1fr; gap:10px}
-.clockbar{display:grid; grid-template-columns:1fr 1fr; gap:8px; align-items:center}
-.clock{display:flex; align-items:center; justify-content:center; background:#0f141c; border:1px solid #222a36; border-radius:10px; padding:10px; font-weight:600; font-size:16px}
-
-.pill.controls{
-  display:flex; gap:8px; align-items:center;
-  background:var(--layer); border:1px solid #222a36; border-radius:10px; padding:6px 8px
+.clockRow {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
 }
-.pill.controls input[type="number"]{
-  width:6em; background:#0f141c; border:1px solid #1c2533; border-radius:6px; padding:4px 8px; color:var(--text)
+.clockbar {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  align-items: center;
+}
+.clock {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0f141c;
+  border: 1px solid #222a36;
+  border-radius: 10px;
+  padding: 10px;
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.pill.controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  background: var(--layer);
+  border: 1px solid #222a36;
+  border-radius: 10px;
+  padding: 6px 8px;
+}
+.pill.controls input[type="number"] {
+  width: 6em;
+  background: #0f141c;
+  border: 1px solid #1c2533;
+  border-radius: 6px;
+  padding: 4px 8px;
+  color: var(--text);
 }
 
 /* PV & puzzle areas */
-.moves{max-height:220px; overflow:auto}
-.status{min-height:22px}
+.moves {
+  max-height: 220px;
+  overflow: auto;
+}
+.status {
+  min-height: 22px;
+}
+#puzzleStatus {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}

--- a/index.html
+++ b/index.html
@@ -315,6 +315,25 @@
         cursor: pointer;
         font-size: 28px;
       }
+      .puzzlePrompt {
+        position: absolute;
+        inset: 0;
+        background: rgba(10, 14, 20, 0.5);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 20;
+      }
+      .puzzlePrompt .box {
+        background: #0c1118;
+        border: 1px solid #1c2533;
+        border-radius: 12px;
+        padding: 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        align-items: center;
+      }
 
       /* Cards */
       .card {
@@ -422,6 +441,13 @@
       .status {
         margin-top: 6px;
         min-height: 24px;
+      }
+      #puzzleStatus {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
       }
       .badge {
         display: inline-flex;
@@ -550,6 +576,9 @@
               ></svg>
             </div>
             <canvas id="fireworks" class="fxCanvas" aria-hidden="true"></canvas>
+
+            <!-- Puzzle completion prompt -->
+            <div class="puzzlePrompt" id="puzzlePrompt"></div>
 
             <!-- Promotion dialog -->
             <div class="promo" id="promo">

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -118,6 +118,7 @@ export class App {
         difficultyLabel: qs("#difficultyLabel"),
         puzzleInfo: qs("#puzzleInfo"),
         puzzleStatus: qs("#puzzleStatus"),
+        puzzlePrompt: qs("#puzzlePrompt"),
       },
       onStateChanged: () => {
         this.syncBoard();

--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -126,6 +126,10 @@ export class PuzzleUI {
     this.index = 0;
     this.autoplayFirst = false;
     if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent = "";
+    if (this.dom?.puzzlePrompt) {
+      this.dom.puzzlePrompt.style.display = "none";
+      this.dom.puzzlePrompt.innerHTML = "";
+    }
     this.clearHint();
   }
 
@@ -241,6 +245,10 @@ export class PuzzleUI {
       this.index = 0;
       this.autoplayFirst = !!p.autoplayFirst;
       this.applyCurrent(true);
+      if (this.dom?.puzzlePrompt) {
+        this.dom.puzzlePrompt.style.display = "none";
+        this.dom.puzzlePrompt.innerHTML = "";
+      }
     } catch (e) {
       alert("Failed to convert puzzle: " + e.message);
     }
@@ -326,11 +334,12 @@ export class PuzzleUI {
   }
 
   promptNewPuzzle() {
-    if (!this.dom?.puzzleStatus) return;
-    this.dom.puzzleStatus.innerHTML =
-      `<span style="color:#39d98a">Solved 🎉</span>` +
-      '<button id="nextPuzzle" style="margin-left:8px">New Puzzle?</button>';
-    const btn = this.dom.puzzleStatus.querySelector("#nextPuzzle");
+    if (this.dom?.puzzleStatus) this.dom.puzzleStatus.textContent = "";
+    if (!this.dom?.puzzlePrompt) return;
+    this.dom.puzzlePrompt.innerHTML =
+      '<div class="box"><span style="color:#39d98a">Solved 🎉</span><button id="nextPuzzle">New Puzzle?</button></div>';
+    this.dom.puzzlePrompt.style.display = "flex";
+    const btn = this.dom.puzzlePrompt.querySelector("#nextPuzzle");
     on(btn, "click", () => this.loadFilteredRandom());
   }
 

--- a/tests/puzzleNextPrompt.test.js
+++ b/tests/puzzleNextPrompt.test.js
@@ -3,10 +3,12 @@ import assert from "node:assert/strict";
 import { PuzzleUI } from "../chess-website-uml/public/src/puzzles/PuzzleUI.js";
 import { Game } from "../chess-website-uml/public/src/core/Game.js";
 
-test("prompts for new puzzle when solved", () => {
+test("prompts for new puzzle when solved and hides after load", async () => {
+  global.alert = () => {};
   const game = new Game();
   let clickHandler;
-  const puzzleStatus = {
+  const puzzlePrompt = {
+    style: {},
     innerHTML: "",
     querySelector() {
       return {
@@ -20,23 +22,34 @@ test("prompts for new puzzle when solved", () => {
     game,
     ui: { clearArrow() {}, drawArrowUci() {} },
     service: {},
-    dom: { puzzleStatus },
+    dom: { puzzlePrompt },
   });
   puzzles.current = { solutionSan: ["e4"] };
   puzzles.index = 0;
 
-  let nextCalled = false;
-  puzzles.loadFilteredRandom = () => {
-    nextCalled = true;
-  };
+  let loaded = false;
+  const done = new Promise((resolve) => {
+    puzzles.loadFilteredRandom = async () => {
+      await puzzles.loadConvertedPuzzle({
+        fen: "k7/8/8/8/8/8/8/K7 w - - 0 1",
+        solution: [],
+      });
+      loaded = true;
+      resolve();
+    };
+  });
 
   const mv = game.move({ from: "e2", to: "e4" });
   assert.ok(mv);
   const res = puzzles.handleUserMove(mv);
   assert.equal(res, true);
-  assert.match(puzzleStatus.innerHTML, /Solved/);
-  assert.match(puzzleStatus.innerHTML, /button/);
+  assert.equal(puzzlePrompt.style.display, "flex");
+  assert.match(puzzlePrompt.innerHTML, /Solved/);
+  assert.match(puzzlePrompt.innerHTML, /button/);
 
   clickHandler();
-  assert.equal(nextCalled, true);
+  await done;
+  assert.equal(loaded, true);
+  assert.equal(puzzlePrompt.style.display, "none");
+  assert.equal(puzzlePrompt.innerHTML, "");
 });


### PR DESCRIPTION
## Summary
- Center the puzzle completion prompt by overlaying it on the board
- Hook up new puzzle prompt overlay in the app and puzzle UI
- Hide the prompt once a new puzzle loads

## Testing
- `npx prettier --write src/puzzles/PuzzleUI.js tests/puzzleNextPrompt.test.js`
- `npm run lint`
- `node --test tests/puzzleNextPrompt.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a31299d5fc832eaebff77e9f113ed7