### PR TITLE
fix: restore difficulty slider handles

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,7 +388,6 @@
         width: 100%;
         pointer-events: none;
         background: none;
-        accent-color: var(--square-dark);
       }
       #difficultySlider input[type="range"]::-webkit-slider-runnable-track,
       #difficultySlider input[type="range"]::-moz-range-track,


### PR DESCRIPTION
## Summary
- remove accent-color override that made difficulty slider handles invisible

## Testing
- `npx prettier --write index.html`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a32c8bc900832ebca5f0b441275ffa