### PR TITLE
fix: enable difficulty slider dragging

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,19 +386,20 @@
         position: absolute;
         left: 0;
         width: 100%;
-        pointer-events: none;
         background: none;
+        pointer-events: none;
       }
       #difficultySlider input[type="range"]::-webkit-slider-runnable-track,
       #difficultySlider input[type="range"]::-moz-range-track,
       #difficultySlider input[type="range"]::-moz-range-progress {
         background: none;
+        pointer-events: none;
       }
       #difficultySlider input[type="range"]::-webkit-slider-thumb,
       #difficultySlider input[type="range"]::-moz-range-thumb {
         -webkit-appearance: none;
         appearance: none;
-        pointer-events: all;
+        pointer-events: auto;
         background: var(--square-light);
         border: none;
         width: 16px;


### PR DESCRIPTION
## Summary
- disable pointer events on range inputs so both difficulty slider handles can be dragged
- keep slider thumbs interactive

## Testing
- `npx prettier --write index.html`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a32e0d0e5c832ebb61bcafeb0a1bea