### PR TITLE
Fix puzzle difficulty slider click handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,19 +387,19 @@
         left: 0;
         width: 100%;
         background: none;
-        pointer-events: auto;
+        pointer-events: none;
       }
       #difficultySlider input[type="range"]::-webkit-slider-runnable-track,
       #difficultySlider input[type="range"]::-moz-range-track,
       #difficultySlider input[type="range"]::-moz-range-progress {
         background: none;
-        pointer-events: auto;
+        pointer-events: none;
       }
       #difficultySlider input[type="range"]::-webkit-slider-thumb,
       #difficultySlider input[type="range"]::-moz-range-thumb {
         -webkit-appearance: none;
         appearance: none;
-        pointer-events: auto;
+        pointer-events: all;
         background: var(--bg);
         border: none;
         width: 16px;
@@ -423,7 +423,6 @@
       }
       #difficultyMax {
         z-index: 2;
-        pointer-events: none;
       }
       #difficultySlider input:disabled {
         opacity: 0.5;


### PR DESCRIPTION
## Summary
- ensure both puzzle difficulty slider handles can be dragged by restricting pointer events to slider thumbs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3454510cc832eb640bc56a9f78a19