### PR TITLE
Fix puzzle difficulty slider click handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,19 +387,19 @@
         left: 0;
         width: 100%;
         background: none;
-        pointer-events: auto;
+        pointer-events: none;
       }
       #difficultySlider input[type="range"]::-webkit-slider-runnable-track,
       #difficultySlider input[type="range"]::-moz-range-track,
       #difficultySlider input[type="range"]::-moz-range-progress {
         background: none;
-        pointer-events: auto;
+        pointer-events: none;
       }
       #difficultySlider input[type="range"]::-webkit-slider-thumb,
       #difficultySlider input[type="range"]::-moz-range-thumb {
         -webkit-appearance: none;
         appearance: none;
-        pointer-events: auto;
+        pointer-events: all;
         background: var(--bg);
         border: none;
         width: 16px;
@@ -423,7 +423,6 @@
       }
       #difficultyMax {
         z-index: 2;
-        pointer-events: none;
       }
       #difficultySlider input:disabled {
         opacity: 0.5;

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -115,6 +115,7 @@ export class App {
         difficultyMin: qs("#difficultyMin"),
         difficultyMax: qs("#difficultyMax"),
         difficultyTrack: qs("#difficultyRangeFill"),
+        difficultySlider: qs("#difficultySlider"),
         difficultyLabel: qs("#difficultyLabel"),
         puzzleInfo: qs("#puzzleInfo"),
         puzzleStatus: qs("#puzzleStatus"),

--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -222,6 +222,29 @@ export class PuzzleUI {
       updateDiffLabel("max");
       this.updateFilterCount();
     });
+    on(d.difficultySlider, "pointerdown", (e) => {
+      if (!d.difficultyFilter?.checked) return;
+      if (e.target === d.difficultyMin || e.target === d.difficultyMax) return;
+      const rect = d.difficultySlider.getBoundingClientRect();
+      const percent = Math.min(
+        Math.max(0, (e.clientX - rect.left) / rect.width),
+        1,
+      );
+      const value = Math.round(percent * 9) + 1;
+      let minVal = parseInt(d.difficultyMin?.value || "1", 10);
+      let maxVal = parseInt(d.difficultyMax?.value || "10", 10);
+      if (Math.abs(value - minVal) <= Math.abs(value - maxVal)) {
+        minVal = Math.min(value, maxVal);
+        if (d.difficultyMin) d.difficultyMin.value = String(minVal);
+        updateDiffLabel("min");
+      } else {
+        maxVal = Math.max(value, minVal);
+        if (d.difficultyMax) d.difficultyMax.value = String(maxVal);
+        updateDiffLabel("max");
+      }
+      this.updateFilterCount();
+      e.preventDefault();
+    });
     syncDiffEnabled();
   }
 


### PR DESCRIPTION
## Summary
- allow puzzle difficulty slider track clicks by wiring container to PuzzleUI
- move nearest handle to clicked position while keeping both thumbs draggable

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3454510cc832eb640bc56a9f78a19