### PR TITLE
Use safe custom event names for opening book

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -558,10 +558,10 @@ export class App {
   askBookMove() {
     return new Promise((resolve) => {
       const onMove = (ev) => resolve(ev?.detail?.san || null);
-      window.addEventListener("book:move", onMove, { once: true });
+      window.addEventListener("book-move", onMove, { once: true });
       const hist = this.getSanHistory();
       window.dispatchEvent(
-        new CustomEvent("book:request", {
+        new CustomEvent("book-request", {
           detail: {
             sanHistory: hist.join(" "),
             ply: hist.length,

--- a/src/engine/boot.js
+++ b/src/engine/boot.js
@@ -2,39 +2,43 @@
 // Late-bound bootstrap so we don't have to change your existing App.js.
 // Wires EngineTuner + OpeningBook to the current DOM and engine.
 
-import { EngineAdapter } from './Adapter.js';
-import { EngineTuner } from './EngineTuner.js';
-import { getBookMove } from './OpeningBook.js';
+import { EngineAdapter } from "./Adapter.js";
+import { EngineTuner } from "./EngineTuner.js";
+import { getBookMove } from "./OpeningBook.js";
 
-const $ = (id)=>document.getElementById(id);
+const $ = (id) => document.getElementById(id);
 
-function collectDom(){
+function collectDom() {
   return {
     // controls
-    mode: $('mode'),
-    auto: $('autoTune'),
-    elo: $('elo'), eloVal: $('eloVal'),
-    depth: $('depth'), depthVal: $('depthVal'),
-    multipv: $('multipv'), multipvVal: $('multipvVal'),
+    mode: $("mode"),
+    auto: $("autoTune"),
+    elo: $("elo"),
+    eloVal: $("eloVal"),
+    depth: $("depth"),
+    depthVal: $("depthVal"),
+    multipv: $("multipv"),
+    multipvVal: $("multipvVal"),
     // badges
-    threadsBadge: $('threadsBadge'),
-    hashBadge: $('hashBadge'),
+    threadsBadge: $("threadsBadge"),
+    hashBadge: $("hashBadge"),
     // misc
-    useBook: $('useBook')
+    useBook: $("useBook"),
   };
 }
 
-function initBook(dom){
+function initBook(dom) {
   // Listen to book requests coming from your App (if it emits them)
-  window.addEventListener('book:request', (ev)=>{
-    const { sanHistory="", ply=0, mode='play' } = ev.detail || {};
+  window.addEventListener("book-request", (ev) => {
+    const { sanHistory = "", ply = 0, mode = "play" } = ev.detail || {};
     const enabled = !!dom.useBook?.checked;
     const san = getBookMove({ sanHistory, ply, mode, enabled });
-    if (san) window.dispatchEvent(new CustomEvent('book:move', { detail:{ san } }));
+    if (san)
+      window.dispatchEvent(new CustomEvent("book-move", { detail: { san } }));
   });
 }
 
-window.addEventListener('load', () => {
+window.addEventListener("load", () => {
   // Find an engine instance if available
   const adapter = new EngineAdapter(window.app?.engine || window.engine);
   const dom = collectDom();


### PR DESCRIPTION
## Summary
- Replace colon-separated custom events with hyphenated versions for opening book requests and responses
- Keep engine and UI in sync via new `book-request` and `book-move` events

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a44a776cbc832ea34d9cffb6af9921