### PR TITLE
Replace puzzle difficulty slider with dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,67 +374,13 @@
         transform: translateY(-50%);
         white-space: nowrap;
       }
-      #difficultySlider {
-        position: relative;
+      #difficultySelects {
+        display: flex;
         flex: 1;
-        height: 24px;
-        background: var(--square-dark);
+        gap: 4px;
       }
-      #difficultySlider input[type="range"] {
-        -webkit-appearance: none;
-        appearance: none;
-        position: absolute;
-        left: 0;
-        width: 100%;
-        background: none;
-        pointer-events: none;
-      }
-      #difficultySlider input[type="range"]::-webkit-slider-runnable-track,
-      #difficultySlider input[type="range"]::-moz-range-track,
-      #difficultySlider input[type="range"]::-moz-range-progress {
-        background: none;
-        pointer-events: none;
-      }
-      #difficultySlider input[type="range"]::-webkit-slider-thumb,
-      #difficultySlider input[type="range"]::-moz-range-thumb {
-        -webkit-appearance: none;
-        appearance: none;
-        pointer-events: all;
-        background: var(--bg);
-        border: none;
-        width: 16px;
-        height: 24px;
-        border-radius: 0;
-      }
-      #difficultyMin::-webkit-slider-thumb,
-      #difficultyMin::-moz-range-thumb {
-        border-left: 2px solid var(--accent);
-        border-top: 2px solid var(--accent);
-        border-bottom: 2px solid var(--accent);
-      }
-      #difficultyMax::-webkit-slider-thumb,
-      #difficultyMax::-moz-range-thumb {
-        border-right: 2px solid var(--accent);
-        border-top: 2px solid var(--accent);
-        border-bottom: 2px solid var(--accent);
-      }
-      #difficultyMin {
-        z-index: 1;
-      }
-      #difficultyMax {
-        z-index: 2;
-      }
-      #difficultySlider input:disabled {
-        opacity: 0.5;
-      }
-      #difficultyRangeFill {
-        position: absolute;
-        top: 50%;
-        height: 4px;
-        background: var(--accent);
-        transform: translateY(-50%);
-        pointer-events: none;
-        z-index: 0;
+      #difficultySelects select {
+        flex: 1;
       }
       @media (max-width: 600px) {
         #difficultyRow {
@@ -643,24 +589,11 @@
                 Difficulty
                 <input type="checkbox" id="difficultyFilter" checked />
               </label>
-              <div id="difficultySlider">
-                <div id="difficultyRangeFill"></div>
-                <input
-                  type="range"
-                  id="difficultyMin"
-                  min="1"
-                  max="10"
-                  value="5"
-                />
-                <input
-                  type="range"
-                  id="difficultyMax"
-                  min="1"
-                  max="10"
-                  value="5"
-                />
+              <div id="difficultySelects">
+                <select id="difficultyMin"></select>
+                <select id="difficultyMax"></select>
               </div>
-              <span class="muted" id="difficultyLabel">Medium (1600-1900)</span>
+              <span class="muted" id="difficultyLabel">Any</span>
             </div>
             <div class="muted" id="puzzleCount"></div>
           </div>

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -114,8 +114,6 @@ export class App {
         difficultyFilter: qs("#difficultyFilter"),
         difficultyMin: qs("#difficultyMin"),
         difficultyMax: qs("#difficultyMax"),
-        difficultyTrack: qs("#difficultyRangeFill"),
-        difficultySlider: qs("#difficultySlider"),
         difficultyLabel: qs("#difficultyLabel"),
         puzzleInfo: qs("#puzzleInfo"),
         puzzleStatus: qs("#puzzleStatus"),

--- a/src/puzzles/PuzzleService.js
+++ b/src/puzzles/PuzzleService.js
@@ -1,4 +1,18 @@
 // Service for loading puzzles from pre-sorted CSV packs.
+
+const RATING_CAPS = [
+  574, 689, 786, 848, 900, 945, 986, 1028, 1069, 1106, 1150, 1187, 1229, 1274,
+  1320, 1366, 1410, 1459, 1504, 1550, 1596, 1642, 1689, 1738, 1791, 1846, 1905,
+  1959, 2017, 2081, 2151, 2225, 2303, 2402, 2550, 2772, 3316,
+];
+
+function ratingToFileIdx(r) {
+  for (let i = 0; i < RATING_CAPS.length; i++) {
+    if (r <= RATING_CAPS[i]) return i + 1;
+  }
+  return RATING_CAPS.length;
+}
+
 export class PuzzleService {
   constructor() {
     this.cache = {};
@@ -32,14 +46,12 @@ export class PuzzleService {
     if (Array.isArray(difficulty)) {
       [difficultyMin, difficultyMax] = difficulty;
     }
-    let min,
-      max,
-      diffEnabled = difficultyMin != null || difficultyMax != null;
+    const diffEnabled = difficultyMin != null || difficultyMax != null;
+    let min = 400,
+      max = 3400;
     if (diffEnabled) {
-      [min] =
-        difficultyMin != null ? diffToRange(difficultyMin) : diffToRange(1);
-      [, max] =
-        difficultyMax != null ? diffToRange(difficultyMax) : diffToRange(10);
+      if (difficultyMin != null) min = difficultyMin;
+      if (difficultyMax != null) max = difficultyMax;
     }
     const themeList = Array.isArray(themes)
       ? themes.filter(Boolean)
@@ -78,29 +90,34 @@ export class PuzzleService {
           : matches;
         if (filtered.length)
           return filtered[(Math.random() * filtered.length) | 0];
-        fallback.push(...matches);
+        for (const m of matches) fallback.push(m);
       }
       return fallback.length
         ? fallback[(Math.random() * fallback.length) | 0]
         : null;
     } else {
-      let fileIdx;
+      let idxMin, idxMax;
       if (!diffEnabled) {
-        fileIdx = ((Math.random() * 37) | 0) + 1;
+        idxMin = idxMax = ((Math.random() * 37) | 0) + 1;
       } else {
-        const target = (min + max) / 2;
-        const step = 2400 / 37;
-        const idx = Math.round((target - 400) / step) + 1;
-        fileIdx = Math.max(1, Math.min(37, idx));
+        idxMin = ratingToFileIdx(min);
+        idxMax = ratingToFileIdx(max);
       }
-      const file = String(fileIdx).padStart(3, "0");
-      const arr = await this.loadCsv(
-        `./lib/lichess_puzzle_db/rating_sort/lichess_db_puzzle_sorted.${file}.csv`,
-      );
-      const matches = arr.filter(
-        (p) =>
-          (!diffEnabled || (p.rating >= min && p.rating <= max)) && byTheme(p),
-      );
+      const matches = [];
+      for (let i = idxMin; i <= idxMax; i++) {
+        const file = String(i).padStart(3, "0");
+        const arr = await this.loadCsv(
+          `./lib/lichess_puzzle_db/rating_sort/lichess_db_puzzle_sorted.${file}.csv`,
+        );
+        for (const p of arr) {
+          if (
+            (!diffEnabled || (p.rating >= min && p.rating <= max)) &&
+            byTheme(p)
+          ) {
+            matches.push(p);
+          }
+        }
+      }
       if (!matches.length) return null;
       const filtered = excludeSet.size
         ? matches.filter((p) => !excludeSet.has(p.id))
@@ -121,14 +138,12 @@ export class PuzzleService {
     if (Array.isArray(difficulty)) {
       [difficultyMin, difficultyMax] = difficulty;
     }
-    let min,
-      max,
-      diffEnabled = difficultyMin != null || difficultyMax != null;
+    const diffEnabled = difficultyMin != null || difficultyMax != null;
+    let min = 400,
+      max = 3400;
     if (diffEnabled) {
-      [min] =
-        difficultyMin != null ? diffToRange(difficultyMin) : diffToRange(1);
-      [, max] =
-        difficultyMax != null ? diffToRange(difficultyMax) : diffToRange(10);
+      if (difficultyMin != null) min = difficultyMin;
+      if (difficultyMax != null) max = difficultyMax;
     }
     const themeList = Array.isArray(themes)
       ? themes.filter(Boolean)
@@ -169,28 +184,30 @@ export class PuzzleService {
       }
       return total;
     } else {
-      let fileIdx;
+      let idxMin, idxMax;
       if (!diffEnabled) {
-        fileIdx = ((Math.random() * 37) | 0) + 1;
+        idxMin = idxMax = ((Math.random() * 37) | 0) + 1;
       } else {
-        const target = (min + max) / 2;
-        const step = 2400 / 37;
-        const idx = Math.round((target - 400) / step) + 1;
-        fileIdx = Math.max(1, Math.min(37, idx));
+        idxMin = ratingToFileIdx(min);
+        idxMax = ratingToFileIdx(max);
       }
-      const file = String(fileIdx).padStart(3, "0");
-      const arr = await this.loadCsv(
-        `./lib/lichess_puzzle_db/rating_sort/lichess_db_puzzle_sorted.${file}.csv`,
-      );
-      const matches = arr.filter(
-        (p) =>
-          (!diffEnabled || (p.rating >= min && p.rating <= max)) && byTheme(p),
-      );
-      if (!matches.length) return 0;
-      const filtered = excludeSet.size
-        ? matches.filter((p) => !excludeSet.has(p.id))
-        : matches;
-      return filtered.length;
+      let total = 0;
+      for (let i = idxMin; i <= idxMax; i++) {
+        const file = String(i).padStart(3, "0");
+        const arr = await this.loadCsv(
+          `./lib/lichess_puzzle_db/rating_sort/lichess_db_puzzle_sorted.${file}.csv`,
+        );
+        const matches = arr.filter(
+          (p) =>
+            (!diffEnabled || (p.rating >= min && p.rating <= max)) &&
+            byTheme(p),
+        );
+        const filtered = excludeSet.size
+          ? matches.filter((p) => !excludeSet.has(p.id))
+          : matches;
+        total += filtered.length;
+      }
+      return total;
     }
   }
 
@@ -224,15 +241,6 @@ export class PuzzleService {
     return out;
   }
 }
-
-export function diffToRange(level) {
-  const base = 400;
-  const step = 300;
-  const min = base + (level - 1) * step;
-  const max = base + level * step;
-  return [min, max];
-}
-
 function get(a, i) {
   return i >= 0 && i < a.length ? a[i] : "";
 }

--- a/tests/puzzleExcludeIds.test.js
+++ b/tests/puzzleExcludeIds.test.js
@@ -9,8 +9,8 @@ test("randomFiltered respects excludeIds", async () => {
     { id: "2", rating: 500, themes: "", openingTags: "" },
   ];
   const res = await svc.randomFiltered({
-    difficultyMin: 1,
-    difficultyMax: 1,
+    difficultyMin: 400,
+    difficultyMax: 800,
     excludeIds: ["1"],
   });
   assert.equal(res.id, "2");

--- a/tests/puzzleFilterCount.test.js
+++ b/tests/puzzleFilterCount.test.js
@@ -4,22 +4,32 @@ import { PuzzleService } from "../chess-website-uml/public/src/puzzles/PuzzleSer
 
 test("countFiltered counts puzzles matching filters", async () => {
   const svc = new PuzzleService();
-  svc.loadCsv = async () => [
-    { id: "1", rating: 500, themes: "fork", openingTags: "A" },
-    { id: "2", rating: 1500, themes: "pin", openingTags: "A" },
-    { id: "3", rating: 800, themes: "fork", openingTags: "B" },
-  ];
-  svc.listOpenings = async () => ({ A: ["001"], B: ["001"] });
+  svc.loadCsv = async (path) => {
+    if (path.includes("opening_sort")) {
+      return [
+        { id: "1", rating: 500, themes: "fork", openingTags: "A" },
+        { id: "2", rating: 1500, themes: "pin", openingTags: "A" },
+      ];
+    }
+    if (path.includes("004")) {
+      return [{ id: "3", rating: 800, themes: "fork", openingTags: "B" }];
+    }
+    return [];
+  };
+  svc.listOpenings = async () => ({ A: ["001"], B: ["004"] });
 
   const cnt1 = await svc.countFiltered({ themes: ["fork"], opening: "A" });
   assert.equal(cnt1, 1);
 
-  const cnt2 = await svc.countFiltered({ difficultyMin: 2, difficultyMax: 3 });
+  const cnt2 = await svc.countFiltered({
+    difficultyMin: 700,
+    difficultyMax: 1000,
+  });
   assert.equal(cnt2, 1);
 
   const cnt3 = await svc.countFiltered({
-    difficultyMin: 2,
-    difficultyMax: 3,
+    difficultyMin: 700,
+    difficultyMax: 1000,
     excludeIds: ["3"],
   });
   assert.equal(cnt3, 0);

--- a/tests/puzzleLargeResultSet.test.js
+++ b/tests/puzzleLargeResultSet.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PuzzleService } from "../chess-website-uml/public/src/puzzles/PuzzleService.js";
+
+test("randomFiltered handles very large result sets", async () => {
+  const svc = new PuzzleService();
+  const big = [];
+  for (let i = 0; i < 70000; i++) {
+    big.push({ id: String(i), rating: 1500, themes: "", openingTags: "" });
+  }
+  svc.loadCsv = async () => big;
+  const res = await svc.randomFiltered({
+    difficultyMin: 0,
+    difficultyMax: 2000,
+  });
+  assert.ok(res?.id);
+});

--- a/tests/puzzlePartialDifficulty.test.js
+++ b/tests/puzzlePartialDifficulty.test.js
@@ -10,7 +10,7 @@ test("randomFiltered with minimum difficulty only", async () => {
   ];
   const origRandom = Math.random;
   Math.random = () => 0;
-  const res = await svc.randomFiltered({ difficultyMin: 2 });
+  const res = await svc.randomFiltered({ difficultyMin: 600 });
   Math.random = origRandom;
   assert.equal(res.id, "2");
 });
@@ -23,7 +23,7 @@ test("randomFiltered with maximum difficulty only", async () => {
   ];
   const origRandom = Math.random;
   Math.random = () => 0;
-  const res = await svc.randomFiltered({ difficultyMax: 2 });
+  const res = await svc.randomFiltered({ difficultyMax: 1000 });
   Math.random = origRandom;
   assert.equal(res.id, "1");
 });

--- a/tests/puzzleThemeFilter.test.js
+++ b/tests/puzzleThemeFilter.test.js
@@ -9,20 +9,20 @@ test("randomFiltered filters by themes", async () => {
     { id: "2", rating: 500, themes: "pin", openingTags: "" },
   ];
   const res1 = await svc.randomFiltered({
-    difficultyMin: 1,
-    difficultyMax: 1,
+    difficultyMin: 400,
+    difficultyMax: 800,
     themes: ["fork"],
   });
   assert.equal(res1.id, "1");
   const res2 = await svc.randomFiltered({
-    difficultyMin: 1,
-    difficultyMax: 1,
+    difficultyMin: 400,
+    difficultyMax: 800,
     themes: ["pin"],
   });
   assert.equal(res2.id, "2");
   const res3 = await svc.randomFiltered({
-    difficultyMin: 1,
-    difficultyMax: 1,
+    difficultyMin: 400,
+    difficultyMax: 800,
     themes: ["skewer"],
   });
   assert.equal(res3, null);


### PR DESCRIPTION
## Summary
- replace puzzle difficulty slider with paired min/max dropdowns, including an ∞ option
- interpret difficulty filters as rating values and update filtering logic accordingly
- map difficulty ranges to rating files using explicit caps, allowing multi-file searches
- avoid stack overflows when filtering large puzzle ranges by iterating over matches instead of spreading arrays
- add regression test covering large result sets

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4545170c4832e989ee571e3710ba2