### PR TITLE
feat: add error handler

### DIFF
--- a/src/util/ErrorHandler.js
+++ b/src/util/ErrorHandler.js
@@ -1,0 +1,28 @@
+export function logError(err, context = "") {
+  console.error(err);
+  const send = globalThis.logToWorker;
+  if (typeof send !== "function") return;
+
+  try {
+    send(JSON.stringify({ error: err, context }));
+  } catch (_e) {
+    const safe = {
+      error:
+        err && typeof err === "object"
+          ? { message: err.message, stack: err.stack, name: err.name }
+          : String(err),
+      context,
+    };
+    try {
+      send(JSON.stringify(safe));
+    } catch (_) {
+      /* swallow */
+    }
+  }
+}
+
+if (typeof globalThis !== "undefined") {
+  globalThis.logError = logError;
+}
+
+export default logError;


### PR DESCRIPTION
## Summary
- add `logError` utility to report errors and forward them to a worker

## Testing
- `npx prettier --write src/util/ErrorHandler.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47c9a5610832e924da9275599a061