### PR TITLE
Log errors from silent catch blocks

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -7,6 +7,7 @@ import { PuzzleUI } from "../puzzles/PuzzleUI.js";
 import { ClockPanel } from "../ui/ClockPanel.js";
 import { detectOpening } from "../engine/Openings.js";
 import { Sounds } from "../util/Sounds.js";
+import { logError } from "../util/ErrorHandler.js";
 
 const qs = (s) => document.querySelector(s);
 
@@ -168,7 +169,10 @@ export class App {
         try {
           navigator.clipboard?.writeText(JSON.stringify(data, null, 2));
           this.engineStatus.textContent = "Copied drawings JSON";
-        } catch {}
+        } catch (err) {
+          logError(err, "App.copyDrawingsJson");
+          this.engineStatus.textContent = "Failed to copy drawings JSON";
+        }
       }
 
       // Import drawings JSON: ⌘/Ctrl+I
@@ -180,7 +184,8 @@ export class App {
         if (!txt) return;
         try {
           this.ui.setUserDrawings?.(JSON.parse(txt));
-        } catch {
+        } catch (err) {
+          logError(err, "App.importDrawingsJson");
           this.engineStatus.textContent = "Invalid drawings JSON";
         }
       }
@@ -272,7 +277,10 @@ export class App {
       try {
         navigator.clipboard?.writeText(pgn);
         this.engineStatus.textContent = "PGN copied";
-      } catch {}
+      } catch (err) {
+        logError(err, "App.copyPgn");
+        this.engineStatus.textContent = "Failed to copy PGN";
+      }
     });
     qs("#loadPgn").addEventListener("click", () => {
       const txt = this.pgnText.value.trim();
@@ -292,7 +300,10 @@ export class App {
       try {
         navigator.clipboard?.writeText(fen);
         this.engineStatus.textContent = "FEN copied";
-      } catch {}
+      } catch (err) {
+        logError(err, "App.copyFen");
+        this.engineStatus.textContent = "Failed to copy FEN";
+      }
     });
     qs("#importFen").addEventListener("click", () => {
       const txt = this.fenText.value.trim();
@@ -853,7 +864,9 @@ export class App {
             }
           }
         }
-      } catch {}
+      } catch (err) {
+        logError(err, "App.maybeCelebrate");
+      }
       this.sounds.play("airhorn");
       this.ui.celebrate?.(kingSq);
     } else if (solvedPuzzle && this.lastCelebrationPly !== ply) {

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -1,49 +1,82 @@
-import { Chess } from '../vendor/chess.mjs';
+import { Chess } from "../vendor/chess.mjs";
+import { logError } from "../util/ErrorHandler.js";
 
 // Wraps chess.js with small conveniences
 export class Game {
-  constructor(){
+  constructor() {
     this.ch = new Chess();
     this.redo = [];
   }
-  reset(){ this.ch.reset(); this.redo.length = 0; }
-  load(fen){ const ok = this.ch.load(fen); if (ok) this.redo.length = 0; return ok; }
-  loadPgn(pgn){ const ok = this.ch.loadPgn(pgn); if (ok) this.redo.length = 0; return ok; }
-  fen(){ return this.ch.fen(); }
-  pgn(){ return this.ch.pgn(); }
-  turn(){ return this.ch.turn(); }
-  inCheck(){ return this.ch.isCheck(); }
-  inCheckmate(){ return this.ch.isCheckmate(); }
-  inDraw(){ return this.ch.isDraw(); }
-  history(){ return this.ch.history(); }
-  historyVerbose(){ return this.ch.history({ verbose:true }); }
-
-  get(square){ return this.ch.get(square) || null; }
-
-  legalMovesFrom(square, color = null){
-    try{
-      if (!color || color === this.ch.turn()){
-        return this.ch.moves({ square, verbose:true }).map(m => m.to);
-      }
-      const parts = this.ch.fen().split(' ');
-      parts[1] = color;
-      const temp = new Chess(parts.join(' '));
-      return temp.moves({ square, verbose:true }).map(m => m.to);
-    }catch{ return []; }
+  reset() {
+    this.ch.reset();
+    this.redo.length = 0;
+  }
+  load(fen) {
+    const ok = this.ch.load(fen);
+    if (ok) this.redo.length = 0;
+    return ok;
+  }
+  loadPgn(pgn) {
+    const ok = this.ch.loadPgn(pgn);
+    if (ok) this.redo.length = 0;
+    return ok;
+  }
+  fen() {
+    return this.ch.fen();
+  }
+  pgn() {
+    return this.ch.pgn();
+  }
+  turn() {
+    return this.ch.turn();
+  }
+  inCheck() {
+    return this.ch.isCheck();
+  }
+  inCheckmate() {
+    return this.ch.isCheckmate();
+  }
+  inDraw() {
+    return this.ch.isDraw();
+  }
+  history() {
+    return this.ch.history();
+  }
+  historyVerbose() {
+    return this.ch.history({ verbose: true });
   }
 
-  premoveLegalMovesFrom(square, color){
+  get(square) {
+    return this.ch.get(square) || null;
+  }
+
+  legalMovesFrom(square, color = null) {
+    try {
+      if (!color || color === this.ch.turn()) {
+        return this.ch.moves({ square, verbose: true }).map((m) => m.to);
+      }
+      const parts = this.ch.fen().split(" ");
+      parts[1] = color;
+      const temp = new Chess(parts.join(" "));
+      return temp.moves({ square, verbose: true }).map((m) => m.to);
+    } catch (err) {
+      logError(err, "Game.legalMovesFrom");
+      return [];
+    }
+  }
+
+  premoveLegalMovesFrom(square, color) {
     const moves = new Set(this.legalMovesFrom(square, color));
     if (!color || color === this.ch.turn()) return Array.from(moves);
-    const baseFenParts = this.ch.fen().split(' ');
+    const baseFenParts = this.ch.fen().split(" ");
     baseFenParts[1] = color;
-    const baseFen = baseFenParts.join(' ');
-    for (const row of this.ch.board()){
-      for (const piece of row){
-        if (piece && piece.color === color && piece.square !== square){
+    const baseFen = baseFenParts.join(" ");
+    for (const row of this.ch.board()) {
+      for (const piece of row) {
+        if (piece && piece.color === color && piece.square !== square) {
           const temp = new Chess(baseFen);
           temp.remove(piece.square);
-          const mvs = temp.moves({ square, verbose: true }).map(m => m.to);
+          const mvs = temp.moves({ square, verbose: true }).map((m) => m.to);
           if (mvs.includes(piece.square)) moves.add(piece.square);
         }
       }
@@ -51,13 +84,30 @@ export class Game {
     return Array.from(moves);
   }
 
-  move(obj){ const m = this.ch.move(obj); if (m) this.redo.length = 0; return m; }
-  moveUci(uci){
-    const m = uci.match(/^([a-h][1-8])([a-h][1-8])([qrbn])?$/); if (!m) return null;
-    return this.move({ from:m[1], to:m[2], promotion:m[3]||undefined });
+  move(obj) {
+    const m = this.ch.move(obj);
+    if (m) this.redo.length = 0;
+    return m;
   }
-  moveSan(san){ const m = this.ch.move(san); if (m) this.redo.length = 0; return m; }
-  undo(){ const u = this.ch.undo(); if (u) this.redo.push(u); return u; }
-  redoOne(){ const u = this.redo.pop(); if (!u) return null; this.ch.move(u); return u; }
+  moveUci(uci) {
+    const m = uci.match(/^([a-h][1-8])([a-h][1-8])([qrbn])?$/);
+    if (!m) return null;
+    return this.move({ from: m[1], to: m[2], promotion: m[3] || undefined });
+  }
+  moveSan(san) {
+    const m = this.ch.move(san);
+    if (m) this.redo.length = 0;
+    return m;
+  }
+  undo() {
+    const u = this.ch.undo();
+    if (u) this.redo.push(u);
+    return u;
+  }
+  redoOne() {
+    const u = this.redo.pop();
+    if (!u) return null;
+    this.ch.move(u);
+    return u;
+  }
 }
-

--- a/src/engine/Adapter.js
+++ b/src/engine/Adapter.js
@@ -2,37 +2,78 @@
 // Normalizes calls to whatever engine wrapper you already have.
 // Pass in your existing engine instance (e.g., window.app.engine or window.engine).
 
+import { logError } from "../util/ErrorHandler.js";
+
 export class EngineAdapter {
   constructor(engineLike) {
     // Try a few common places
     this.eng = engineLike || window.app?.engine || window.engine || null;
   }
 
-  hasEngine(){ return !!this.eng; }
+  hasEngine() {
+    return !!this.eng;
+  }
 
   setOption(name, value) {
     try {
       if (this.eng?.setOption) return this.eng.setOption(name, value);
-      if (this.eng?.send)      return this.eng.send(`setoption name ${name} value ${value}`);
-    } catch {}
+      if (this.eng?.send)
+        return this.eng.send(`setoption name ${name} value ${value}`);
+    } catch (err) {
+      logError(err, "EngineAdapter.setOption");
+    }
   }
 
   setDepth(n) {
-    try { return this.eng?.setDepth ? this.eng.setDepth(n) : this.eng?.send?.(`depth ${n}`); } catch {}
+    try {
+      return this.eng?.setDepth
+        ? this.eng.setDepth(n)
+        : this.eng?.send?.(`depth ${n}`);
+    } catch (err) {
+      logError(err, "EngineAdapter.setDepth");
+    }
   }
 
   setMoveTime(ms) {
-    try { return this.eng?.setMoveTime ? this.eng.setMoveTime(ms) : this.eng?.send?.(`movetime ${ms}`); } catch {}
+    try {
+      return this.eng?.setMoveTime
+        ? this.eng.setMoveTime(ms)
+        : this.eng?.send?.(`movetime ${ms}`);
+    } catch (err) {
+      logError(err, "EngineAdapter.setMoveTime");
+    }
   }
 
   setMultiPV(n) {
     try {
       if (this.eng?.setMultiPV) return this.eng.setMultiPV(n);
-      this.setOption('MultiPV', n);
-    } catch {}
+      this.setOption("MultiPV", n);
+    } catch (err) {
+      logError(err, "EngineAdapter.setMultiPV");
+    }
   }
 
-  setPlayPrefs(opts){ try { return this.eng?.setPlayPrefs?.(opts); } catch {} }
-  warmup(){ try { return this.eng?.warmup?.(); } catch {} }
-  send(cmd){ try { return this.eng?.send?.(cmd); } catch {} }
+  setPlayPrefs(opts) {
+    try {
+      return this.eng?.setPlayPrefs?.(opts);
+    } catch (err) {
+      logError(err, "EngineAdapter.setPlayPrefs");
+    }
+  }
+
+  warmup() {
+    try {
+      return this.eng?.warmup?.();
+    } catch (err) {
+      logError(err, "EngineAdapter.warmup");
+    }
+  }
+
+  send(cmd) {
+    try {
+      return this.eng?.send?.(cmd);
+    } catch (err) {
+      logError(err, "EngineAdapter.send");
+    }
+  }
 }

--- a/src/engine/TimeManager.js
+++ b/src/engine/TimeManager.js
@@ -1,11 +1,13 @@
 import { Chess } from "../vendor/chess.mjs";
+import { logError } from "../util/ErrorHandler.js";
 
 export function estimateComplexity(fen) {
   let moves = [];
   try {
     const ch = new Chess(fen);
     moves = ch.moves({ verbose: true });
-  } catch {
+  } catch (err) {
+    logError(err, "TimeManager.estimateComplexity");
     return 0;
   }
   let complexity = moves.length;

--- a/src/puzzles/PuzzleModel.js
+++ b/src/puzzles/PuzzleModel.js
@@ -1,4 +1,5 @@
 import { Chess } from "../vendor/chess.mjs";
+import { logError } from "../util/ErrorHandler.js";
 
 // Accepts various shapes:
 // - Lichess daily/byId: { puzzle:{ id, fen, solution:[uci...]|"uci...", moves:[uci...]|"uci...", rating, themes, gameId? }, game:{ id? } }
@@ -117,7 +118,8 @@ function fenFromPgn(pgn, ply) {
       if (game.move(moves[i])) count++;
     }
     return game.fen();
-  } catch {
+  } catch (err) {
+    logError(err, "PuzzleModel.fenFromPgn");
     return "";
   }
 }

--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -1,5 +1,6 @@
 import { Chess } from "../vendor/chess.mjs";
 import { adaptLichessPuzzle } from "./PuzzleModel.js";
+import { logError } from "../util/ErrorHandler.js";
 
 function on(el, type, fn) {
   if (el) el.addEventListener(type, fn);
@@ -133,7 +134,11 @@ export class PuzzleUI {
         );
       }
       this.dom.openingSel.innerHTML = opts.join("");
-    } catch {}
+    } catch (err) {
+      logError(err, "PuzzleUI.populateOpenings");
+      if (this.dom?.puzzleStatus)
+        this.dom.puzzleStatus.textContent = "Failed to load openings";
+    }
   }
 
   populateThemes() {
@@ -147,7 +152,9 @@ export class PuzzleUI {
         opts.push(`<option value="${name}">${label}</option>`);
       }
       this.dom.themeSel.innerHTML = opts.join("");
-    } catch {}
+    } catch (err) {
+      logError(err, "PuzzleUI.populateThemes");
+    }
   }
 
   bindDom() {
@@ -279,8 +286,9 @@ export class PuzzleUI {
       const noun = count === 1 ? "puzzle" : "puzzles";
       const verb = count === 1 ? "fits" : "fit";
       this.dom.puzzleCount.textContent = `${count} ${noun} ${verb} your filter`;
-    } catch {
-      this.dom.puzzleCount.textContent = "";
+    } catch (err) {
+      logError(err, "PuzzleUI.updateFilterCount");
+      this.dom.puzzleCount.textContent = "Error fetching count";
     }
   }
 

--- a/src/ui/BoardUI.js
+++ b/src/ui/BoardUI.js
@@ -7,6 +7,8 @@
 // - Click-to-move selection + legal dots; drag preserved
 // - Opponent/book primary arrows ignored; all arrows cleared on setFen()
 
+import { logError } from "../util/ErrorHandler.js";
+
 const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
 
 // Use the *black* glyph codepoints for BOTH sides (solid shapes)
@@ -676,7 +678,9 @@ export class BoardUI {
       e.preventDefault();
       try {
         this.boardEl.setPointerCapture(e.pointerId);
-      } catch {}
+      } catch (err) {
+        logError(err, "BoardUI.attachLeftDrag");
+      }
 
       // Drag ghost uses black glyph too; color/outline set by .pw/.pb class on the ghost
       this.dragStart = {
@@ -752,7 +756,9 @@ export class BoardUI {
   onPointerUp(e) {
     try {
       this.boardEl.releasePointerCapture(e.pointerId);
-    } catch {}
+    } catch (err) {
+      logError(err, "BoardUI.onPointerUp");
+    }
     if (this._rafHandle) {
       cancelAnimationFrame(this._rafHandle);
       this._rafHandle = 0;

--- a/src/ui/DrawOverlay.js
+++ b/src/ui/DrawOverlay.js
@@ -1,4 +1,3 @@
-
 // public/src/ui/DrawOverlay.js
 // Right-click drawing overlay (v3)
 //
@@ -11,122 +10,168 @@
 //
 // Colors: none=green, Shift=red, Alt=yellow, Ctrl/⌘=blue.
 
-(function(){
-  'use strict';
+(function () {
+  "use strict";
 
-  function colorFromMods(e){
-    if (e.shiftKey) return 'r';
-    if (e.altKey) return 'y';
-    if (e.ctrlKey || e.metaKey) return 'b';
-    return 'g';
+  function colorFromMods(e) {
+    if (e.shiftKey) return "r";
+    if (e.altKey) return "y";
+    if (e.ctrlKey || e.metaKey) return "b";
+    return "g";
   }
-  function colorToCss(key){
-    switch (key){
-      case 'r': return '#ff5d5d';
-      case 'y': return '#ffd166';
-      case 'b': return '#69a7ff';
-      default:  return '#39d98a'; // g
+  function colorToCss(key) {
+    switch (key) {
+      case "r":
+        return "#ff5d5d";
+      case "y":
+        return "#ffd166";
+      case "b":
+        return "#69a7ff";
+      default:
+        return "#39d98a"; // g
     }
   }
 
-  const FILES = ['a','b','c','d','e','f','g','h'];
-  function squareAt(cell, orientation, x, y){
+  const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"];
+  function squareAt(cell, orientation, x, y) {
     if (!cell) return null;
-    const orientWhite = (orientation === 'white');
+    const orientWhite = orientation === "white";
     const file = Math.max(0, Math.min(7, Math.floor(x / cell)));
     const rank = Math.max(0, Math.min(7, Math.floor(y / cell)));
     const xf = orientWhite ? file : 7 - file;
     const yr = orientWhite ? 7 - rank : rank;
-    return `${FILES[xf]}${yr+1}`;
+    return `${FILES[xf]}${yr + 1}`;
   }
-  function squareCenter(square, cell, orientation){
+  function squareCenter(square, cell, orientation) {
     const f = square.charCodeAt(0) - 97;
-    const r = parseInt(square[1],10) - 1;
-    const orientWhite = (orientation === 'white');
-    const x = orientWhite ? f : (7 - f);
-    const y = orientWhite ? (7 - r) : r;
-    return { x: (x + 0.5)*cell, y: (y + 0.5)*cell };
+    const r = parseInt(square[1], 10) - 1;
+    const orientWhite = orientation === "white";
+    const x = orientWhite ? f : 7 - f;
+    const y = orientWhite ? 7 - r : r;
+    return { x: (x + 0.5) * cell, y: (y + 0.5) * cell };
   }
 
-  function ensureOverlay(boardEl){
-    let svg = boardEl.querySelector('#arrowSvg, svg.draw-overlay');
-    if (!svg){
-      svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
-      svg.setAttribute('id', 'arrowSvg');
-      svg.classList.add('draw-overlay');
-      svg.style.position = 'absolute';
-      svg.style.inset = '0';
-      svg.style.pointerEvents = 'none';
+  function ensureOverlay(boardEl) {
+    let svg = boardEl.querySelector("#arrowSvg, svg.draw-overlay");
+    if (!svg) {
+      svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      svg.setAttribute("id", "arrowSvg");
+      svg.classList.add("draw-overlay");
+      svg.style.position = "absolute";
+      svg.style.inset = "0";
+      svg.style.pointerEvents = "none";
       boardEl.appendChild(svg);
     }
-    svg.innerHTML = '';
-    const gUser = document.createElementNS('http://www.w3.org/2000/svg','g'); gUser.setAttribute('class','user-arrows');
-    const gSys = document.createElementNS('http://www.w3.org/2000/svg','g'); gSys.setAttribute('class','sys-arrows');
-    const gPreview = document.createElementNS('http://www.w3.org/2000/svg','g'); gPreview.setAttribute('class','preview-arrow');
-    const gMarks = document.createElementNS('http://www.w3.org/2000/svg','g'); gMarks.setAttribute('class','user-marks');
-    svg.appendChild(gUser); svg.appendChild(gSys); svg.appendChild(gPreview); svg.appendChild(gMarks);
+    svg.innerHTML = "";
+    const gUser = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    gUser.setAttribute("class", "user-arrows");
+    const gSys = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    gSys.setAttribute("class", "sys-arrows");
+    const gPreview = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "g",
+    );
+    gPreview.setAttribute("class", "preview-arrow");
+    const gMarks = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    gMarks.setAttribute("class", "user-marks");
+    svg.appendChild(gUser);
+    svg.appendChild(gSys);
+    svg.appendChild(gPreview);
+    svg.appendChild(gMarks);
     return { svg, gUser, gSys, gPreview, gMarks };
   }
 
-  function drawArrowOnLayer(layer, fromSq, toSq, color, sw, cell, orientation, dataKey){
+  function drawArrowOnLayer(
+    layer,
+    fromSq,
+    toSq,
+    color,
+    sw,
+    cell,
+    orientation,
+    dataKey,
+  ) {
     const a = squareCenter(fromSq, cell, orientation);
     const b = squareCenter(toSq, cell, orientation);
-    const ux = (b.x - a.x), uy = (b.y - a.y);
-    const len = Math.hypot(ux,uy) || 1;
-    const nx = ux/len, ny = uy/len;
-    const headLen = Math.max(cell*0.28, 18);
-    const headW   = Math.max(sw*1.0, cell*0.18);
-    const sx2 = b.x - nx*headLen;
-    const sy2 = b.y - ny*headLen;
+    const ux = b.x - a.x,
+      uy = b.y - a.y;
+    const len = Math.hypot(ux, uy) || 1;
+    const nx = ux / len,
+      ny = uy / len;
+    const headLen = Math.max(cell * 0.28, 18);
+    const headW = Math.max(sw * 1.0, cell * 0.18);
+    const sx2 = b.x - nx * headLen;
+    const sy2 = b.y - ny * headLen;
 
-    const line = document.createElementNS('http://www.w3.org/2000/svg','line');
-    line.setAttribute('x1', a.x); line.setAttribute('y1', a.y);
-    line.setAttribute('x2', sx2); line.setAttribute('y2', sy2);
-    line.setAttribute('stroke', color);
-    line.setAttribute('stroke-width', sw);
-    line.setAttribute('stroke-linecap', 'round');
+    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    line.setAttribute("x1", a.x);
+    line.setAttribute("y1", a.y);
+    line.setAttribute("x2", sx2);
+    line.setAttribute("y2", sy2);
+    line.setAttribute("stroke", color);
+    line.setAttribute("stroke-width", sw);
+    line.setAttribute("stroke-linecap", "round");
 
-    const npx = -ny, npy = nx;
-    const tri = document.createElementNS('http://www.w3.org/2000/svg','polygon');
-    tri.setAttribute('points', `${b.x},${b.y} ${sx2+npx*headW},${sy2+npy*headW} ${sx2-npx*headW},${sy2-npy*headW}`);
-    tri.setAttribute('fill', color);
-    tri.setAttribute('stroke', color);
-    tri.setAttribute('stroke-linejoin', 'round');
-    tri.setAttribute('stroke-width', Math.max(1, sw*0.25));
+    const npx = -ny,
+      npy = nx;
+    const tri = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "polygon",
+    );
+    tri.setAttribute(
+      "points",
+      `${b.x},${b.y} ${sx2 + npx * headW},${sy2 + npy * headW} ${sx2 - npx * headW},${sy2 - npy * headW}`,
+    );
+    tri.setAttribute("fill", color);
+    tri.setAttribute("stroke", color);
+    tri.setAttribute("stroke-linejoin", "round");
+    tri.setAttribute("stroke-width", Math.max(1, sw * 0.25));
 
-    const g = document.createElementNS('http://www.w3.org/2000/svg','g');
-    if (dataKey) g.setAttribute('data-uci', dataKey);
-    g.appendChild(line); g.appendChild(tri);
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    if (dataKey) g.setAttribute("data-uci", dataKey);
+    g.appendChild(line);
+    g.appendChild(tri);
     layer.appendChild(g);
   }
 
-  function drawCircleOnLayer(layer, sq, color, sw, cell, orientation, dataKey){
+  function drawCircleOnLayer(layer, sq, color, sw, cell, orientation, dataKey) {
     const c = squareCenter(sq, cell, orientation);
     const r = cell * 0.36;
-    const ring = document.createElementNS('http://www.w3.org/2000/svg','circle');
-    ring.setAttribute('cx', c.x);
-    ring.setAttribute('cy', c.y);
-    ring.setAttribute('r', r);
-    ring.setAttribute('stroke', color);
-    ring.setAttribute('stroke-width', Math.max(6, Math.floor(sw*0.85)));
-    ring.setAttribute('fill', 'none');
-    if (dataKey) ring.setAttribute('data-circle', dataKey);
+    const ring = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "circle",
+    );
+    ring.setAttribute("cx", c.x);
+    ring.setAttribute("cy", c.y);
+    ring.setAttribute("r", r);
+    ring.setAttribute("stroke", color);
+    ring.setAttribute("stroke-width", Math.max(6, Math.floor(sw * 0.85)));
+    ring.setAttribute("fill", "none");
+    if (dataKey) ring.setAttribute("data-circle", dataKey);
     layer.appendChild(ring);
   }
 
-  function DrawOverlay(boardEl){
+  function DrawOverlay(boardEl) {
     this.boardEl = boardEl;
     const cs = getComputedStyle(boardEl);
-    if (cs.position === 'static') boardEl.style.position = 'relative';
+    if (cs.position === "static") boardEl.style.position = "relative";
 
     const { svg, gUser, gSys, gPreview, gMarks } = ensureOverlay(boardEl);
-    this.svg = svg; this.gUser = gUser; this.gSys = gSys; this.gPreview = gPreview; this.gMarks = gMarks;
+    this.svg = svg;
+    this.gUser = gUser;
+    this.gSys = gSys;
+    this.gPreview = gPreview;
+    this.gMarks = gMarks;
 
     this.userArrows = new Set();
     this.userCircles = new Set();
     this.drawStart = null;
     this.cell = 0;
-    this.orientation = (boardEl.getAttribute('data-orientation') || boardEl.dataset?.orientation) === 'black' ? 'black' : 'white';
+    this.orientation =
+      (boardEl.getAttribute("data-orientation") ||
+        boardEl.dataset?.orientation) === "black"
+        ? "black"
+        : "white";
 
     // snapshots keyed by move ply
     this._snapsByPly = new Map();
@@ -136,213 +181,315 @@
     this.attachRightDraw();
     this.attachLeftClear(); // clear on left click / pointer-up
 
-    boardEl.addEventListener('contextmenu', (e)=> e.preventDefault(), true);
-    window.addEventListener('resize', ()=>{ this.updateMetrics(); this.resizeOverlay(); this.redrawAll(); });
+    boardEl.addEventListener("contextmenu", (e) => e.preventDefault(), true);
+    window.addEventListener("resize", () => {
+      this.updateMetrics();
+      this.resizeOverlay();
+      this.redrawAll();
+    });
   }
 
-  DrawOverlay.prototype.updateMetrics = function(){
+  DrawOverlay.prototype.updateMetrics = function () {
     const r = this.boardEl.getBoundingClientRect();
     const size = Math.min(r.width || 0, r.height || 0);
     this.cell = (size || 0) / 8 || 0;
-    const attr = this.boardEl.getAttribute('data-orientation') || this.boardEl.dataset?.orientation;
-    if (attr === 'black' || attr === 'white') this.orientation = attr;
+    const attr =
+      this.boardEl.getAttribute("data-orientation") ||
+      this.boardEl.dataset?.orientation;
+    if (attr === "black" || attr === "white") this.orientation = attr;
   };
 
-  DrawOverlay.prototype.resizeOverlay = function(){
+  DrawOverlay.prototype.resizeOverlay = function () {
     const r = this.boardEl.getBoundingClientRect();
     const size = Math.min(r.width || 0, r.height || 0);
-    this.svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
+    this.svg.setAttribute("viewBox", `0 0 ${size} ${size}`);
     this.svg.style.width = `${size}px`;
     this.svg.style.height = `${size}px`;
   };
 
-  DrawOverlay.prototype.redrawAll = function(){
-    this.gUser.innerHTML = '';
-    this.gMarks.innerHTML = '';
-    const sw = Math.max(8, Math.floor(this.cell*0.14));
-    for (const key of this.userArrows){
-      const [uci, c='g'] = key.split(':');
-      const from = uci.slice(0,2), to = uci.slice(2,4);
-      drawArrowOnLayer(this.gUser, from, to, colorToCss(c), sw, this.cell, this.orientation, key);
+  DrawOverlay.prototype.redrawAll = function () {
+    this.gUser.innerHTML = "";
+    this.gMarks.innerHTML = "";
+    const sw = Math.max(8, Math.floor(this.cell * 0.14));
+    for (const key of this.userArrows) {
+      const [uci, c = "g"] = key.split(":");
+      const from = uci.slice(0, 2),
+        to = uci.slice(2, 4);
+      drawArrowOnLayer(
+        this.gUser,
+        from,
+        to,
+        colorToCss(c),
+        sw,
+        this.cell,
+        this.orientation,
+        key,
+      );
     }
-    for (const key of this.userCircles){
-      const [sq, c='g'] = key.split(':');
-      drawCircleOnLayer(this.gMarks, sq, colorToCss(c), sw, this.cell, this.orientation, key);
+    for (const key of this.userCircles) {
+      const [sq, c = "g"] = key.split(":");
+      drawCircleOnLayer(
+        this.gMarks,
+        sq,
+        colorToCss(c),
+        sw,
+        this.cell,
+        this.orientation,
+        key,
+      );
     }
   };
 
-  DrawOverlay.prototype.renderPreview = function(fromSq, toSq, colorKey){
-    this.gPreview.innerHTML = '';
+  DrawOverlay.prototype.renderPreview = function (fromSq, toSq, colorKey) {
+    this.gPreview.innerHTML = "";
     if (!fromSq || !toSq) return;
-    const sw = Math.max(7, Math.floor(this.cell*0.12));
-    const color = colorToCss(colorKey) + '90'; // ~56% alpha
-    drawArrowOnLayer(this.gPreview, fromSq, toSq, color, sw, this.cell, this.orientation);
+    const sw = Math.max(7, Math.floor(this.cell * 0.12));
+    const color = colorToCss(colorKey) + "90"; // ~56% alpha
+    drawArrowOnLayer(
+      this.gPreview,
+      fromSq,
+      toSq,
+      color,
+      sw,
+      this.cell,
+      this.orientation,
+    );
   };
 
-  DrawOverlay.prototype.attachRightDraw = function(){
+  DrawOverlay.prototype.attachRightDraw = function () {
     const hasPointer = !!window.PointerEvent;
     const onDown = (e) => {
-      const isRight = (e.button === 2) || (e.buttons & 2) || (!!e.ctrlKey && e.button === 0);
+      const isRight =
+        e.button === 2 || e.buttons & 2 || (!!e.ctrlKey && e.button === 0);
       if (!isRight) return;
       const rect = this.boardEl.getBoundingClientRect();
-      const x = e.clientX - rect.left, y = e.clientY - rect.top;
+      const x = e.clientX - rect.left,
+        y = e.clientY - rect.top;
       const fromSq = squareAt(this.cell, this.orientation, x, y);
       if (!fromSq) return;
 
       e.preventDefault();
       const modKey = colorFromMods(e);
-      this.drawStart = { fromSq, x0: e.clientX, y0: e.clientY, modKey, pointerId: hasPointer ? e.pointerId : -1 };
+      this.drawStart = {
+        fromSq,
+        x0: e.clientX,
+        y0: e.clientY,
+        modKey,
+        pointerId: hasPointer ? e.pointerId : -1,
+      };
       this.renderPreview(fromSq, fromSq, modKey);
 
-      const blockCtx = (ev)=> ev.preventDefault();
-      document.addEventListener('contextmenu', blockCtx, { capture:true, once:true });
+      const blockCtx = (ev) => ev.preventDefault();
+      document.addEventListener("contextmenu", blockCtx, {
+        capture: true,
+        once: true,
+      });
 
-      if (hasPointer){
+      if (hasPointer) {
         const move = (ev) => {
-          if (!this.drawStart || (ev.pointerId !== this.drawStart.pointerId)) return;
-          const rx = ev.clientX - rect.left, ry = ev.clientY - rect.top;
-          const toSq = squareAt(this.cell, this.orientation, rx, ry) || this.drawStart.fromSq;
-          this.renderPreview(this.drawStart.fromSq, toSq, this.drawStart.modKey);
+          if (!this.drawStart || ev.pointerId !== this.drawStart.pointerId)
+            return;
+          const rx = ev.clientX - rect.left,
+            ry = ev.clientY - rect.top;
+          const toSq =
+            squareAt(this.cell, this.orientation, rx, ry) ||
+            this.drawStart.fromSq;
+          this.renderPreview(
+            this.drawStart.fromSq,
+            toSq,
+            this.drawStart.modKey,
+          );
         };
         const up = (ev) => {
-          if (!this.drawStart || (ev.pointerId !== this.drawStart.pointerId)) return;
-          document.removeEventListener('pointermove', move, true);
-          document.removeEventListener('pointerup', up, true);
+          if (!this.drawStart || ev.pointerId !== this.drawStart.pointerId)
+            return;
+          document.removeEventListener("pointermove", move, true);
+          document.removeEventListener("pointerup", up, true);
           this.finishRightDrag(ev);
         };
-        document.addEventListener('pointermove', move, true);
-        document.addEventListener('pointerup', up, true);
+        document.addEventListener("pointermove", move, true);
+        document.addEventListener("pointerup", up, true);
       } else {
         const move = (ev) => {
           if (!this.drawStart) return;
-          const rx = ev.clientX - rect.left, ry = ev.clientY - rect.top;
-          const toSq = squareAt(this.cell, this.orientation, rx, ry) || this.drawStart.fromSq;
-          this.renderPreview(this.drawStart.fromSq, toSq, this.drawStart.modKey);
+          const rx = ev.clientX - rect.left,
+            ry = ev.clientY - rect.top;
+          const toSq =
+            squareAt(this.cell, this.orientation, rx, ry) ||
+            this.drawStart.fromSq;
+          this.renderPreview(
+            this.drawStart.fromSq,
+            toSq,
+            this.drawStart.modKey,
+          );
         };
         const up = (ev) => {
-          document.removeEventListener('mousemove', move, true);
-          document.removeEventListener('mouseup', up, true);
+          document.removeEventListener("mousemove", move, true);
+          document.removeEventListener("mouseup", up, true);
           this.finishRightDrag(ev);
         };
-        document.addEventListener('mousemove', move, true);
-        document.addEventListener('mouseup', up, true);
+        document.addEventListener("mousemove", move, true);
+        document.addEventListener("mouseup", up, true);
       }
     };
 
-    if (hasPointer){
-      this.boardEl.addEventListener('pointerdown', onDown);
+    if (hasPointer) {
+      this.boardEl.addEventListener("pointerdown", onDown);
     } else {
-      this.boardEl.addEventListener('mousedown', onDown);
+      this.boardEl.addEventListener("mousedown", onDown);
     }
   };
 
   // Clear on left click / pointer-up:
-  DrawOverlay.prototype.attachLeftClear = function(){
+  DrawOverlay.prototype.attachLeftClear = function () {
     const hasPointer = !!window.PointerEvent;
     const onClear = (e) => {
-      const left = (e.button === 0) || (hasPointer && e.pointerType && e.button === 0);
+      const left =
+        e.button === 0 || (hasPointer && e.pointerType && e.button === 0);
       if (!left) return;
       // Record snapshot then clear
       this.recordSnapshot();
       this.clearAll();
     };
-    if (hasPointer){
-      this.boardEl.addEventListener('pointerup', onClear);
+    if (hasPointer) {
+      this.boardEl.addEventListener("pointerup", onClear);
     } else {
-      this.boardEl.addEventListener('mouseup', onClear);
+      this.boardEl.addEventListener("mouseup", onClear);
     }
     // Also treat a simple click as clear (as requested)
-    this.boardEl.addEventListener('click', (e)=>{
+    this.boardEl.addEventListener("click", (e) => {
       if (e.button !== 0) return;
       this.recordSnapshot();
       this.clearAll();
     });
   };
 
-  DrawOverlay.prototype.currentPly = function(){
+  DrawOverlay.prototype.currentPly = function () {
     const app = window.app;
-    if (app){
+    if (app) {
       return app.inReview ? app.reviewPly : app.getSanHistory().length;
     }
     return 0;
   };
 
-  DrawOverlay.prototype.recordSnapshot = function(){
+  DrawOverlay.prototype.recordSnapshot = function () {
     const ply = this.currentPly();
     this._snapsByPly.set(ply, this.getUserDrawings());
   };
 
-  DrawOverlay.prototype.restoreSnapshotForPly = function(ply){
+  DrawOverlay.prototype.restoreSnapshotForPly = function (ply) {
     const snap = this._snapsByPly.get(ply);
-    this.setUserDrawings(snap || { arrows:[], circles:[] });
+    this.setUserDrawings(snap || { arrows: [], circles: [] });
   };
 
-  DrawOverlay.prototype.finishRightDrag = function(e){
-    const start = this.drawStart; this.drawStart = null;
-    this.gPreview.innerHTML = '';
+  DrawOverlay.prototype.finishRightDrag = function (e) {
+    const start = this.drawStart;
+    this.drawStart = null;
+    this.gPreview.innerHTML = "";
     if (!start) return;
 
     const rect = this.boardEl.getBoundingClientRect();
-    const toSq = squareAt(this.cell, this.orientation, e.clientX - rect.left, e.clientY - rect.top) || start.fromSq;
-    const dx = e.clientX - start.x0, dy = e.clientY - start.y0;
-    const movedEnough = (dx*dx + dy*dy) > 16;
+    const toSq =
+      squareAt(
+        this.cell,
+        this.orientation,
+        e.clientX - rect.left,
+        e.clientY - rect.top,
+      ) || start.fromSq;
+    const dx = e.clientX - start.x0,
+      dy = e.clientY - start.y0;
+    const movedEnough = dx * dx + dy * dy > 16;
 
-    const colorKey = start.modKey || 'g';
+    const colorKey = start.modKey || "g";
     const color = colorToCss(colorKey);
-    const sw = Math.max(8, Math.floor(this.cell*0.14));
+    const sw = Math.max(8, Math.floor(this.cell * 0.14));
 
-    if (!movedEnough || toSq === start.fromSq){
+    if (!movedEnough || toSq === start.fromSq) {
       const ckey = `${start.fromSq}:${colorKey}`;
-      if (this.userCircles.has(ckey)){
+      if (this.userCircles.has(ckey)) {
         this.userCircles.delete(ckey);
         this.gMarks.querySelector(`[data-circle="${ckey}"]`)?.remove();
       } else {
         this.userCircles.add(ckey);
-        drawCircleOnLayer(this.gMarks, start.fromSq, color, sw, this.cell, this.orientation, ckey);
+        drawCircleOnLayer(
+          this.gMarks,
+          start.fromSq,
+          color,
+          sw,
+          this.cell,
+          this.orientation,
+          ckey,
+        );
       }
       return;
     }
 
     const uci = start.fromSq + toSq;
     const akey = `${uci}:${colorKey}`;
-    if (this.userArrows.has(akey)){
+    if (this.userArrows.has(akey)) {
       this.userArrows.delete(akey);
       this.gUser.querySelector(`[data-uci="${akey}"]`)?.remove();
     } else {
       this.userArrows.add(akey);
-      drawArrowOnLayer(this.gUser, start.fromSq, toSq, color, sw, this.cell, this.orientation, akey);
+      drawArrowOnLayer(
+        this.gUser,
+        start.fromSq,
+        toSq,
+        color,
+        sw,
+        this.cell,
+        this.orientation,
+        akey,
+      );
     }
   };
 
-  DrawOverlay.prototype.clearAll = function(){
+  DrawOverlay.prototype.clearAll = function () {
     this.userArrows.clear();
     this.userCircles.clear();
-    this.gUser.innerHTML = '';
-    this.gMarks.innerHTML = '';
-    this.gPreview.innerHTML = '';
+    this.gUser.innerHTML = "";
+    this.gMarks.innerHTML = "";
+    this.gPreview.innerHTML = "";
     // also clear system arrows if present (engine lines)
-    try { this.svg.querySelector('.sys-arrows').innerHTML = ''; } catch {}
+    try {
+      this.svg.querySelector(".sys-arrows").innerHTML = "";
+    } catch (err) {
+      window.logError?.(err, "DrawOverlay.clearAll");
+    }
   };
 
-  DrawOverlay.prototype.getUserDrawings = function(){
+  DrawOverlay.prototype.getUserDrawings = function () {
     return {
-      arrows: Array.from(this.userArrows).map(k => { const [uci,color='g']=k.split(':'); return {uci,color}; }),
-      circles: Array.from(this.userCircles).map(k => { const [sq,color='g']=k.split(':'); return {sq,color}; })
+      arrows: Array.from(this.userArrows).map((k) => {
+        const [uci, color = "g"] = k.split(":");
+        return { uci, color };
+      }),
+      circles: Array.from(this.userCircles).map((k) => {
+        const [sq, color = "g"] = k.split(":");
+        return { sq, color };
+      }),
     };
   };
-  DrawOverlay.prototype.setUserDrawings = function(obj){
-    this.userArrows.clear(); this.userCircles.clear();
-    if (obj && Array.isArray(obj.arrows)){
-      for (const a of obj.arrows){ this.userArrows.add(`${a.uci}:${a.color||'g'}`); }
+  DrawOverlay.prototype.setUserDrawings = function (obj) {
+    this.userArrows.clear();
+    this.userCircles.clear();
+    if (obj && Array.isArray(obj.arrows)) {
+      for (const a of obj.arrows) {
+        this.userArrows.add(`${a.uci}:${a.color || "g"}`);
+      }
     }
-    if (obj && Array.isArray(obj.circles)){
-      for (const c of obj.circles){ this.userCircles.add(`${c.sq}:${c.color||'g'}`); }
+    if (obj && Array.isArray(obj.circles)) {
+      for (const c of obj.circles) {
+        this.userCircles.add(`${c.sq}:${c.color || "g"}`);
+      }
     }
     this.redrawAll();
   };
 
-  document.addEventListener('DOMContentLoaded', function(){
-    const boardEl = document.getElementById('board') || document.querySelector('.board, #chessboard, .board-container');
+  document.addEventListener("DOMContentLoaded", function () {
+    const boardEl =
+      document.getElementById("board") ||
+      document.querySelector(".board, #chessboard, .board-container");
     if (!boardEl) return;
     if (boardEl.__drawOverlay) return;
     boardEl.__drawOverlay = true;

--- a/src/ui/SysArrowPolicy.js
+++ b/src/ui/SysArrowPolicy.js
@@ -1,26 +1,31 @@
-
 // public/src/ui/SysArrowPolicy.js
 // Prevent engine/system arrows from appearing during play mode.
 // Assumes there is a <select id="modeSel"> or element with data-mode reflecting 'play' | 'analysis' | 'puzzle'.
 // If absent, defaults to 'play' to be conservative.
 
-(function(){
-  function currentMode(){
-    const sel = document.getElementById('modeSel') || document.querySelector('[data-mode]');
-    if (!sel) return 'play';
+(function () {
+  function currentMode() {
+    const sel =
+      document.getElementById("modeSel") ||
+      document.querySelector("[data-mode]");
+    if (!sel) return "play";
     if (sel.value) return sel.value;
-    const v = sel.getAttribute('data-mode') || sel.dataset?.mode;
-    return v || 'play';
+    const v = sel.getAttribute("data-mode") || sel.dataset?.mode;
+    return v || "play";
   }
   const proto = window.BoardUI && window.BoardUI.prototype;
-  if (!proto || typeof proto.drawArrowUci !== 'function') return;
+  if (!proto || typeof proto.drawArrowUci !== "function") return;
 
   const orig = proto.drawArrowUci;
-  proto.drawArrowUci = function(uci, primary){
+  proto.drawArrowUci = function (uci, primary) {
     // Clear old sys arrows each time
-    try { this.clearArrow && this.clearArrow(); } catch {}
+    try {
+      this.clearArrow && this.clearArrow();
+    } catch (err) {
+      window.logError?.(err, "SysArrowPolicy.drawArrowUci");
+    }
     // Only draw in analysis mode
-    if (currentMode() !== 'analysis') return;
+    if (currentMode() !== "analysis") return;
     return orig.call(this, uci, primary);
   };
 })();

--- a/src/util/ErrorHandler.js
+++ b/src/util/ErrorHandler.js
@@ -1,0 +1,7 @@
+export function logError(err, context) {
+  console.error(`[${context}]`, err);
+}
+
+if (typeof window !== "undefined") {
+  window.logError = logError;
+}

--- a/src/util/Sounds.js
+++ b/src/util/Sounds.js
@@ -1,3 +1,5 @@
+import { logError } from "./ErrorHandler.js";
+
 export class Sounds {
   constructor() {
     this.ctx = null;
@@ -62,8 +64,8 @@ export class Sounds {
       osc.stop(now + p.dur);
 
       gain.connect(ctx.destination);
-    } catch {
-      // ignore playback errors
+    } catch (err) {
+      logError(err, "Sounds.play");
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a simple `logError` utility that also attaches to `window`
- replace empty `catch {}` blocks with `catch (err)` and `logError`
- surface user-facing status text when clipboard or puzzle lookups fail

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47cab9cf4832e854a811ce23d1ee0