### PR TITLE
Add loading spinner for puzzles

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,6 +334,19 @@
         gap: 8px;
         align-items: center;
       }
+      .puzzlePrompt .spinner {
+        width: 40px;
+        height: 40px;
+        border: 4px solid #1c2533;
+        border-top-color: #39d98a;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
 
       /* Cards */
       .card {
@@ -561,6 +574,17 @@
 
             <!-- Puzzle completion prompt -->
             <div class="puzzlePrompt" id="puzzlePrompt"></div>
+
+            <!-- Puzzle loading prompt -->
+            <div class="puzzlePrompt" id="puzzleLoading">
+              <div class="box">
+                <div class="spinner"></div>
+                <div>
+                  Loading... To load your puzzle faster, Sam recommends a
+                  smaller sample size in the filter below!
+                </div>
+              </div>
+            </div>
 
             <!-- Promotion dialog -->
             <div class="promo" id="promo">

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -119,6 +119,7 @@ export class App {
         puzzleStatus: qs("#puzzleStatus"),
         puzzleCount: qs("#puzzleCount"),
         puzzlePrompt: qs("#puzzlePrompt"),
+        puzzleLoading: qs("#puzzleLoading"),
       },
       onStateChanged: () => {
         this.syncBoard();
@@ -225,10 +226,13 @@ export class App {
         this.puzzles.resetProgress();
         this.clockPanel.pause();
         try {
+          this.puzzles.showLoading(true);
           const p = await this.puzzleService.fetchDaily();
           await this.puzzles.loadConvertedPuzzle({ ...p, daily: true });
         } catch (e) {
           this.engineStatus.textContent = "Daily puzzle fetch failed";
+        } finally {
+          this.puzzles.showLoading(false);
         }
       }
       this.refreshAll();

--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -110,6 +110,10 @@ export class PuzzleUI {
     if (this.dom?.clockWhite)
       this.dom.clockWhite.style.display = flag ? "none" : "";
   }
+  showLoading(flag) {
+    if (this.dom?.puzzleLoading)
+      this.dom.puzzleLoading.style.display = flag ? "flex" : "none";
+  }
   resetProgress() {
     this.index = 0;
     this.autoplayFirst = false;
@@ -212,6 +216,7 @@ export class PuzzleUI {
   }
 
   async loadFilteredRandom() {
+    this.showLoading(true);
     try {
       const diffEnabled = this.dom.difficultyFilter?.checked;
       const parseVal = (el) =>
@@ -236,6 +241,8 @@ export class PuzzleUI {
       await this.loadConvertedPuzzle({ ...p, autoplayFirst: true });
     } catch (e) {
       alert("Failed to load puzzle: " + e.message);
+    } finally {
+      this.showLoading(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- show puzzle loading spinner with helpful guidance
- wire spinner into puzzle and daily puzzle loaders

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47eaa91d0832eae525fa87d378be4