### PR TITLE
Use DejaVu Sans font for uniform chess piece rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 An open-source chess website where all processing happens client-side with no external dependencies. The project showcases a pure HTML, CSS, and JavaScript approach and serves as an experiment with code generated via ChatGPT.
 
 ## Overview
+
 - **Fully client-side**: no backend server required.
 - **Vendor-free**: aside from bundled libraries such as [chess.mjs](chess-website-uml/public/src/vendor/chess.mjs).
 - **Educational**: aimed at experimenting with AI-assisted development and modern browser capabilities.
 
 ## Architecture
+
 Source code lives under `chess-website-uml/public` and is organized into:
+
 - `src/app` – application bootstrap and high-level controllers
 - `src/ui` – DOM rendering and user interaction helpers
 - `src/vendor` – third-party libraries bundled with the project
@@ -16,6 +19,7 @@ Source code lives under `chess-website-uml/public` and is organized into:
 See [ARCHITECTURE.md](ARCHITECTURE.md) for a deeper dive.
 
 ## Development
+
 The client-side code requires specific cross-origin isolation headers. A small Python server is provided to serve the site with the required headers.
 
 ```bash
@@ -24,11 +28,16 @@ npm run dev
 
 This hosts the site at `http://127.0.0.1:8080/`.
 
+### Piece font
+
+For consistent chess piece rendering across platforms, download the [DejaVu Sans](https://github.com/dejavu-fonts/dejavu-fonts/raw/master/ttf/DejaVuSans.ttf) font and place it at `css/fonts/DejaVuSans.ttf`.
+
 ### Engine variants
 
 By default the site runs the original lightweight engine. For a stronger engine with enhanced evaluation you can append `?engine=strong` to the URL (e.g. `http://127.0.0.1:8080/?engine=strong`). This makes it easy to A/B test the classic and strong engines.
 
 ## Testing
+
 Unit tests are written with the built-in Node.js test runner.
 
 ```bash
@@ -36,7 +45,9 @@ npm test
 ```
 
 ## Contributing
+
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to get started and the project's coding standards.
 
 ## License
+
 This project is licensed under the [MIT License](LICENSE).

--- a/css/board.css
+++ b/css/board.css
@@ -1,3 +1,9 @@
+@font-face {
+  font-family: "DejaVu Sans";
+  src: url("./fonts/DejaVuSans.ttf") format("truetype");
+  font-display: swap;
+}
+
 /* Board card + board grid */
 .board-wrap {
   position: relative;
@@ -31,9 +37,17 @@
 /* Use stylized, monochrome chess fonts (no emoji/photorealistic) */
 .piece {
   font-family:
-    "Noto Sans Symbols2", "Segoe UI Symbol", "DejaVu Sans", "Symbola",
+    "DejaVu Sans", "Noto Sans Symbols2", "Segoe UI Symbol", "Symbola",
     "FreeSerif", serif;
   font-variant-emoji: text; /* force text presentation where supported */
+}
+
+.sq .glyph,
+.dragPiece.glyph {
+  font-family:
+    "DejaVu Sans", "Noto Sans Symbols2", "Segoe UI Symbol", "Symbola",
+    "FreeSerif", serif;
+  font-variant-emoji: text;
 }
 
 .sq {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,12 @@
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
 
     <style>
+      @font-face {
+        font-family: "DejaVu Sans";
+        src: url("./css/fonts/DejaVuSans.ttf") format("truetype");
+        font-display: swap;
+      }
+
       :root {
         --bg: #0f1216;
         --layer: #141922;
@@ -208,7 +214,7 @@
       /* Unicode chess pieces (black glyphs for both; recolored via CSS) */
       .piece {
         font-family:
-          "Noto Sans Symbols2", "Segoe UI Symbol", "DejaVu Sans", "Symbola",
+          "DejaVu Sans", "Noto Sans Symbols2", "Segoe UI Symbol", "Symbola",
           "FreeSerif", serif;
         font-variant-emoji: text;
       }

--- a/src/ui/BoardUI.js
+++ b/src/ui/BoardUI.js
@@ -36,6 +36,7 @@ const BLACK_GLYPH = {
       display: inline-block;
       line-height: 1;
       font-size: calc(var(--cell) * 0.82);
+      font-family: "DejaVu Sans", "Noto Sans Symbols2", "Segoe UI Symbol", "Symbola", "FreeSerif", serif;
       font-variant-emoji: text;
       --glyph-outline-width: max(0.6px, calc(var(--cell) * 0.01));
       /* Outline color is provided via --glyph-outline (set by piece color) */


### PR DESCRIPTION
## Summary
- remove bundled DejaVu Sans binary font
- document font download and placement for consistent piece glyphs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4943187ac832e8ea48a1799249fad