### PR TITLE
Handle D1 worker row responses in PuzzleService

### DIFF
--- a/src/puzzles/PuzzleService.js
+++ b/src/puzzles/PuzzleService.js
@@ -62,13 +62,16 @@ export class PuzzleService {
     });
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     const data = await r.json();
-    return (
+    let rows =
       data?.results ||
       data?.result?.[0]?.results ||
-      data?.result?.[0] ||
+      data?.result?.results ||
+      data?.rows ||
+      data?.row ||
       data?.result ||
-      []
-    );
+      [];
+    if (!Array.isArray(rows)) rows = [rows];
+    return rows;
   }
 
   async randomFiltered(opts = {}) {


### PR DESCRIPTION
## Summary
- Handle Cloudflare worker responses that return a single `row` or `rows` in `PuzzleService.queryD1`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ac7d879c832ea82994a10821ab71