### PR TITLE
Remove puzzle difficulty checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,10 +613,7 @@
               <select id="themeFilter" style="flex: 1"></select>
             </div>
             <div class="row" id="difficultyRow">
-              <label>
-                Difficulty
-                <input type="checkbox" id="difficultyFilter" checked />
-              </label>
+              <label>Difficulty</label>
               <div id="difficultySelects">
                 <select id="difficultyMin"></select>
                 <select id="difficultyMax"></select>

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -111,7 +111,6 @@ export class App {
         hintBtn: qs("#puzzleHint"),
         openingSel: qs("#openingFilter"),
         themeSel: qs("#themeFilter"),
-        difficultyFilter: qs("#difficultyFilter"),
         difficultyMin: qs("#difficultyMin"),
         difficultyMax: qs("#difficultyMax"),
         difficultyLabel: qs("#difficultyLabel"),

--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -195,15 +195,6 @@ export class PuzzleUI {
         d.difficultyLabel.textContent = text;
       }
     };
-    const syncDiffEnabled = () => {
-      const enabled = d.difficultyFilter?.checked;
-      if (d.difficultyMin) d.difficultyMin.disabled = !enabled;
-      if (d.difficultyMax) d.difficultyMax.disabled = !enabled;
-      if (enabled) updateDiffLabel();
-      else if (d.difficultyLabel) d.difficultyLabel.textContent = "Any";
-      this.updateFilterCount();
-    };
-    on(d.difficultyFilter, "change", syncDiffEnabled);
     on(d.difficultyMin, "change", () => {
       updateDiffLabel("min");
       this.updateFilterCount();
@@ -212,17 +203,16 @@ export class PuzzleUI {
       updateDiffLabel("max");
       this.updateFilterCount();
     });
-    syncDiffEnabled();
+    updateDiffLabel();
   }
 
   async loadFilteredRandom() {
     this.showLoading(true);
     try {
-      const diffEnabled = this.dom.difficultyFilter?.checked;
       const parseVal = (el) =>
         el && el.value !== "" ? parseInt(el.value, 10) : null;
-      const diffMin = diffEnabled ? parseVal(this.dom.difficultyMin) : null;
-      const diffMax = diffEnabled ? parseVal(this.dom.difficultyMax) : null;
+      const diffMin = parseVal(this.dom.difficultyMin);
+      const diffMax = parseVal(this.dom.difficultyMax);
       const opening = this.dom.openingSel?.value || "";
       const theme = this.dom.themeSel?.value || "";
       const themes = theme ? [theme] : [];
@@ -267,11 +257,10 @@ export class PuzzleUI {
   async updateFilterCount() {
     if (!this.dom?.puzzleCount) return;
     try {
-      const diffEnabled = this.dom.difficultyFilter?.checked;
       const parseVal = (el) =>
         el && el.value !== "" ? parseInt(el.value, 10) : null;
-      const diffMin = diffEnabled ? parseVal(this.dom.difficultyMin) : null;
-      const diffMax = diffEnabled ? parseVal(this.dom.difficultyMax) : null;
+      const diffMin = parseVal(this.dom.difficultyMin);
+      const diffMax = parseVal(this.dom.difficultyMax);
       const opening = this.dom.openingSel?.value || "";
       const theme = this.dom.themeSel?.value || "";
       const themes = theme ? [theme] : [];


### PR DESCRIPTION
## Summary
- remove difficulty checkbox from puzzle filters
- streamline PuzzleUI to always use difficulty range selectors
- drop unused DOM reference in App initialization

## Testing
- `npx prettier --write index.html src/app/App.js src/puzzles/PuzzleUI.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a5849b10832e88ca79e95d0e8141