### PR TITLE
docs: describe hosting and cloudflare dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Guidance for Automated Agents
 
-This repository hosts the **chess-by-z** client-side chess website.
+This repository hosts the **chess-by-z** chess website. Gameplay runs in the browser while puzzle data comes from a Cloudflare D1 database via a worker.
 Follow these guidelines when modifying the project.
 
 ## Repository layout

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # Architecture
 
-The project is a static client-side application. The key components are:
+The project is a static site whose UI and engine run in the browser while puzzle data is retrieved from a Cloudflare Worker backed by a D1 database. The key components are:
 
 - **App layer (`src/app`)**: bootstraps the application and wires together UI and engine logic.
 - **UI layer (`src/ui`)**: renders the chess board, handles user interaction, and updates the DOM.
 - **Engine & utilities (`src/vendor`)**: third-party libraries such as `chess.mjs` provide core chess logic.
 
-The application is served by a lightweight Python script that adds the required security headers for cross-origin isolation.
+For local development a lightweight Python script adds the required security headers for cross-origin isolation. In production the static assets are hosted on GitHub Pages and puzzle queries are proxied through the Cloudflare Worker.
 
 ```
 chess-website-uml/public

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # chess-by-z
 
-An open-source chess website where all processing happens client-side with no external dependencies. The project showcases a pure HTML, CSS, and JavaScript approach and serves as an experiment with code generated via ChatGPT.
+An open-source chess website hosted on GitHub Pages. Gameplay runs in the browser while puzzle data is served by a Cloudflare Worker backed by a D1 database. The project showcases a pure HTML, CSS, and JavaScript approach and serves as an experiment with code generated via ChatGPT.
 
 ## Overview
 
-- **Fully client-side**: no backend server required.
-- **Vendor-free**: aside from bundled libraries such as [chess.mjs](chess-website-uml/public/src/vendor/chess.mjs).
+- **Hosted via GitHub Pages** with puzzles queried through a Cloudflare Worker and D1 database.
+- **Browser-based**: the chess engine and UI run entirely in the user's browser.
 - **Educational**: aimed at experimenting with AI-assisted development and modern browser capabilities.
+
+## Hosting
+
+The static site is published at <https://fettimbapro.github.io/chess-by-z/>. Puzzle requests are proxied through a Cloudflare Worker that queries a D1 database (see [cloudflare/lichess-puzzle-db/worker.js](cloudflare/lichess-puzzle-db/worker.js)). To use your own backend, deploy a worker and set `window.PUZZLE_D1_URL` to its endpoint.
 
 ## Architecture
 
@@ -20,7 +24,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for a deeper dive.
 
 ## Development
 
-The client-side code requires specific cross-origin isolation headers. A small Python server is provided to serve the site with the required headers.
+The frontend requires specific cross-origin isolation headers. A small Python server is provided to serve the site with the required headers for local development.
 
 ```bash
 npm run dev

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "chess-by-z",
   "version": "1.0.0",
-  "description": "Open-source client-side chess website",
+  "description": "Open-source chess website with Cloudflare-hosted puzzle database",
   "scripts": {
     "dev": "python chess-website-uml/public/serve.py",
     "test": "node --test tests/**/*.test.js",
     "lint": "eslint ."
   },
-  "keywords": ["chess", "client-side"],
+  "keywords": [
+    "chess"
+  ],
   "author": "",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- document GitHub Pages hosting and Cloudflare D1 worker dependency
- adjust architecture and AGENTS guidance to reflect backend usage
- update package metadata to remove "client-side" wording

## Testing
- `npx prettier --write README.md ARCHITECTURE.md AGENTS.md package.json`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a77bb3f8832e9c462d8b0e11b36a