### PR TITLE
Improve strong engine transposition table reuse

### DIFF
--- a/src/workers/strong-engine.js
+++ b/src/workers/strong-engine.js
@@ -145,6 +145,11 @@ function pushKiller(uci, ply) {
   }
 }
 
+// Transposition table key ignoring halfmove/fullmove counters
+function ttKey(ch) {
+  return ch.fen().split(" ").slice(0, 4).join(" ");
+}
+
 function orderMoves(list, ttUci, ply, ch) {
   const ks = killers[ply] || [];
   return list
@@ -556,8 +561,8 @@ function timeUp() {
 }
 
 function search(ch, depth, alpha, beta, ply) {
-  // TT probe
-  const key = ch.fen(); // includes side/castling/EP
+  // TT probe with normalized key
+  const key = ttKey(ch);
   const tte = TT.get(key);
   if (tte && tte.depth >= depth) {
     const s = tte.score;


### PR DESCRIPTION
## Summary
- normalize strong engine TT keys by stripping move counters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b96128ec832e970e42adb348f25c