### PR TITLE
feat: add puzzles endpoint

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting...</title>
+    <script>
+      sessionStorage.redirect = location.href;
+      window.location.replace("/chess-by-z/");
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,16 @@
   <head>
     <meta charset="utf-8" />
     <title>Chess by Sam</title>
+    <base href="/chess-by-z/" />
+    <script>
+      const redirect = sessionStorage.redirect;
+      if (redirect) {
+        delete sessionStorage.redirect;
+        if (redirect !== location.href) {
+          history.replaceState(null, "", redirect);
+        }
+      }
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0f1216" />
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
@@ -583,9 +593,7 @@
             <div class="puzzlePrompt" id="puzzleLoading">
               <div class="box">
                 <div class="spinner"></div>
-                <div>
-                  Loading...
-                </div>
+                <div>Loading...</div>
               </div>
             </div>
 

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -68,6 +68,9 @@ export class App {
     this.engine = new WorkerEngine({ variant: engineVariant });
     this.sounds = new Sounds();
 
+    // Base path for routing (e.g., "", "/", or "/subdir/")
+    this.basePath = window.location.pathname.replace(/\/puzzles\/?$/, "/");
+
     // Clock UI
     this.clockPanel = new ClockPanel({ clock: this.clock, els: clockEls });
     this.clock.onFlag = (side) => {
@@ -141,6 +144,12 @@ export class App {
     // Init
     this.bindControls();
     this.bindReviewHotkeys();
+
+    const initialMode = /\/puzzles\/?$/.test(window.location.pathname)
+      ? "puzzle"
+      : "play";
+    this.setMode(initialMode);
+    this.updateUrlMode();
 
     // --- Drawing hotkeys ---
     window.addEventListener("keydown", (e) => {
@@ -240,6 +249,7 @@ export class App {
       this.updateModeButtonStyles();
       this.updateSwitchButtonVisibility();
       this.updateAdvancedControlsVisibility();
+      this.updateUrlMode();
     });
 
     this.sideSel.addEventListener("change", () => {
@@ -381,6 +391,16 @@ export class App {
     if (this.modeSel.value === mode) return;
     this.modeSel.value = mode;
     this.modeSel.dispatchEvent(new Event("change"));
+  }
+
+  updateUrlMode() {
+    const path =
+      this.modeSel.value === "puzzle"
+        ? this.basePath + "puzzles"
+        : this.basePath;
+    if (window.location.pathname !== path) {
+      history.replaceState(null, "", path + window.location.search);
+    }
   }
 
   updateModeButtonStyles() {


### PR DESCRIPTION
## Summary
- route `/puzzles` directly to puzzle mode
- keep URL in sync with mode selection
- serve `index.html` for unknown paths using a redirect-based 404 to avoid duplicate files

## Testing
- `npx prettier --write index.html 404.html`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d090fd64832ea4dd382c378c6b21