### PR TITLE
Expose runMatches utility for engine simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ For consistent chess piece rendering across platforms, download the [DejaVu Sans
 
 By default the site runs the original lightweight engine. For a stronger engine with enhanced evaluation you can append `?engine=strong` to the URL (e.g. `http://127.0.0.1:8080/?engine=strong`). This makes it easy to A/B test the classic and strong engines.
 
+### Simulating engine matches in the browser
+
+The engine exposes a helper for running multiple **strong vs. classic** matches at once. After starting the development server and opening the site, run the following in the browser console:
+
+```js
+await runMatches(10); // run 10 simultaneous matches
+```
+
+Each match logs its move list and final PGN, grouped in the console. Omit the numeric argument to use the default of 10 matches.
+
 ## Testing & Linting
 
 Use ESLint for code style checks and Node's built-in test runner for unit

--- a/src/engine/boot.js
+++ b/src/engine/boot.js
@@ -5,6 +5,7 @@
 import { EngineAdapter } from "./Adapter.js";
 import { EngineTuner } from "./EngineTuner.js";
 import { getBookMove } from "./OpeningBook.js";
+import "./runMatches.js";
 
 const $ = (id) => document.getElementById(id);
 

--- a/src/engine/runMatches.js
+++ b/src/engine/runMatches.js
@@ -1,0 +1,66 @@
+import { WorkerEngine } from "./WorkerEngine.js";
+import { Chess } from "../vendor/chess.mjs";
+
+async function runMatch(id) {
+  const strong = new WorkerEngine({ variant: "strong" });
+  const weak = new WorkerEngine({ variant: "classic" });
+  const game = new Chess();
+
+  let side = strong;
+  let ply = 1;
+  const log = [];
+
+  while (!game.isGameOver()) {
+    const moveUci = await side.play(game.fen());
+    if (!moveUci) {
+      log.push(
+        `ply ${ply}: ${side === strong ? "strong" : "weak"} had no legal move`,
+      );
+      break;
+    }
+    game.move({
+      from: moveUci.slice(0, 2),
+      to: moveUci.slice(2, 4),
+      promotion: moveUci[4],
+    });
+    log.push(
+      `ply ${ply}: ${side === strong ? "strong" : "weak"} -> ${moveUci}`,
+    );
+    side = side === strong ? weak : strong;
+    ply++;
+  }
+
+  const result = game.isCheckmate()
+    ? side === strong
+      ? "weak wins"
+      : "strong wins"
+    : "draw";
+
+  strong.worker.terminate();
+  weak.worker.terminate();
+
+  return { id, result, pgn: game.pgn(), log };
+}
+
+export async function runMatches(n = 10) {
+  if (typeof Worker === "undefined") {
+    const { Worker } = await import("node:worker_threads");
+    globalThis.Worker = Worker;
+  }
+
+  const matches = Array.from({ length: n }, (_, i) => runMatch(i + 1));
+  const results = await Promise.all(matches);
+
+  for (const match of results) {
+    console.group(`Match ${match.id}: ${match.result}`);
+    match.log.forEach((line) => console.log(line));
+    console.log(`PGN: ${match.pgn}`);
+    console.groupEnd();
+  }
+
+  return results;
+}
+
+if (typeof window !== "undefined") {
+  window.runMatches = runMatches;
+}


### PR DESCRIPTION
## Summary
- add runMatches.js to simulate multiple strong vs classic engine matches
- import runMatches in boot.js to expose window.runMatches in browser
- document how to run browser-based engine matches via runMatches
- log PGN instead of FEN for match output

## Testing
- `npx prettier --write README.md src/engine/runMatches.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5bf89584c832ea71acb4852c694ce