### PR TITLE
Load opening book dynamically with runtime toggle

### DIFF
--- a/src/engine/OpeningBook.js
+++ b/src/engine/OpeningBook.js
@@ -2,22 +2,30 @@
 // Compact offline opening book containing only named openings.
 // Keys are SAN sequences joined by spaces; values are arrays of [SAN, weight].
 
-import BOOK from './openingBookData.js';
+let bookPromise;
 
-function pickWeighted(list){
-  const total = list.reduce((a,[,w])=>a+w,0);
-  let r = Math.random()*total;
-  for(const [m,w] of list){
+async function loadBook() {
+  if (!bookPromise) {
+    bookPromise = import("./openingBookData.js").then((m) => m.default);
+  }
+  return bookPromise;
+}
+
+function pickWeighted(list) {
+  const total = list.reduce((a, [, w]) => a + w, 0);
+  let r = Math.random() * total;
+  for (const [m, w] of list) {
     r -= w;
-    if(r<=0) return m;
+    if (r <= 0) return m;
   }
   return list[0][0];
 }
 
-export function getBookMove({ sanHistory, ply, mode, enabled=true }) {
-  if (!enabled || mode !== 'play') return null;
-  if (typeof ply === 'number' && ply >= 12) return null; // limit to ~6 moves each side
-  const key = String(sanHistory || '').trim();
-  const entry = BOOK[key];
+export async function getBookMove({ sanHistory, ply, mode, enabled = true }) {
+  if (!enabled || mode !== "play") return null;
+  if (typeof ply === "number" && ply >= 12) return null; // limit to ~6 moves each side
+  const book = await loadBook();
+  const key = String(sanHistory || "").trim();
+  const entry = book[key];
   return entry ? pickWeighted(entry) : null;
 }

--- a/src/engine/boot.js
+++ b/src/engine/boot.js
@@ -29,11 +29,20 @@ function collectDom() {
 }
 
 function initBook(dom) {
+  let bookEnabled = !!dom.useBook?.checked;
+  dom.useBook?.addEventListener("change", () => {
+    bookEnabled = !!dom.useBook.checked;
+  });
+
   // Listen to book requests coming from your App (if it emits them)
-  window.addEventListener("book-request", (ev) => {
+  window.addEventListener("book-request", async (ev) => {
     const { sanHistory = "", ply = 0, mode = "play" } = ev.detail || {};
-    const enabled = !!dom.useBook?.checked;
-    const san = getBookMove({ sanHistory, ply, mode, enabled });
+    const san = await getBookMove({
+      sanHistory,
+      ply,
+      mode,
+      enabled: bookEnabled,
+    });
     if (san)
       window.dispatchEvent(new CustomEvent("book-move", { detail: { san } }));
   });


### PR DESCRIPTION
## Summary
- Dynamically import opening book data only when needed and avoid loading outside play mode.
- Track `useBook` checkbox and load book moves asynchronously, enabling runtime enable/disable.

## Testing
- `npx prettier --write src/engine/OpeningBook.js src/engine/boot.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72806c330832ea6429821f3eada91