### PR TITLE
fix: ensure board renders on initial load

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -907,4 +907,16 @@ export class App {
   }
 }
 
-window.addEventListener("DOMContentLoaded", () => new App());
+if (
+  typeof window !== "undefined" &&
+  typeof document !== "undefined" &&
+  typeof document.querySelector === "function" &&
+  typeof document.querySelectorAll === "function" &&
+  typeof window.addEventListener === "function"
+) {
+  if (document.readyState === "loading") {
+    window.addEventListener("DOMContentLoaded", () => new App());
+  } else {
+    new App();
+  }
+}


### PR DESCRIPTION
## Summary
- ensure `App` initializes immediately if the DOM is already ready
- guard auto-initialization to skip non-browser environments

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72f123f6c832e9af36495fb30ac43