### PR TITLE
Allow deselecting piece by clicking it

### DIFF
--- a/src/ui/BoardUI.js
+++ b/src/ui/BoardUI.js
@@ -854,6 +854,13 @@ export class BoardUI {
       const sq = sqEl.dataset.square;
       const piece = this.getPieceAt(sq);
 
+      if (this.selected === sq) {
+        this.clearSelectionDots();
+        this.selected = null;
+        this.dragTargets = new Set();
+        return;
+      }
+
       // Move if selected and target is legal
       if (this.selected && this.dragTargets.has(sq)) {
         const pieceSel = this.getPieceAt(this.selected);


### PR DESCRIPTION
## Summary
- Allow clearing legal move indicators by clicking the currently selected piece

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a732905010832e8044d0819fbe4f5c