### PR TITLE
Allow pseudo-legal premoves

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -1,63 +1,126 @@
-import { Chess } from '../vendor/chess.mjs';
+import { Chess } from "../vendor/chess.mjs";
 
 // Wraps chess.js with small conveniences
 export class Game {
-  constructor(){
+  constructor() {
     this.ch = new Chess();
     this.redo = [];
   }
-  reset(){ this.ch.reset(); this.redo.length = 0; }
-  load(fen){ const ok = this.ch.load(fen); if (ok) this.redo.length = 0; return ok; }
-  loadPgn(pgn){ const ok = this.ch.loadPgn(pgn); if (ok) this.redo.length = 0; return ok; }
-  fen(){ return this.ch.fen(); }
-  pgn(){ return this.ch.pgn(); }
-  turn(){ return this.ch.turn(); }
-  inCheck(){ return this.ch.isCheck(); }
-  inCheckmate(){ return this.ch.isCheckmate(); }
-  inDraw(){ return this.ch.isDraw(); }
-  history(){ return this.ch.history(); }
-  historyVerbose(){ return this.ch.history({ verbose:true }); }
-
-  get(square){ return this.ch.get(square) || null; }
-
-  legalMovesFrom(square, color = null){
-    try{
-      if (!color || color === this.ch.turn()){
-        return this.ch.moves({ square, verbose:true }).map(m => m.to);
-      }
-      const parts = this.ch.fen().split(' ');
-      parts[1] = color;
-      const temp = new Chess(parts.join(' '));
-      return temp.moves({ square, verbose:true }).map(m => m.to);
-    }catch{ return []; }
+  reset() {
+    this.ch.reset();
+    this.redo.length = 0;
+  }
+  load(fen) {
+    const ok = this.ch.load(fen);
+    if (ok) this.redo.length = 0;
+    return ok;
+  }
+  loadPgn(pgn) {
+    const ok = this.ch.loadPgn(pgn);
+    if (ok) this.redo.length = 0;
+    return ok;
+  }
+  fen() {
+    return this.ch.fen();
+  }
+  pgn() {
+    return this.ch.pgn();
+  }
+  turn() {
+    return this.ch.turn();
+  }
+  inCheck() {
+    return this.ch.isCheck();
+  }
+  inCheckmate() {
+    return this.ch.isCheckmate();
+  }
+  inDraw() {
+    return this.ch.isDraw();
+  }
+  history() {
+    return this.ch.history();
+  }
+  historyVerbose() {
+    return this.ch.history({ verbose: true });
   }
 
-  premoveLegalMovesFrom(square, color){
-    const moves = new Set(this.legalMovesFrom(square, color));
-    if (!color || color === this.ch.turn()) return Array.from(moves);
-    const baseFenParts = this.ch.fen().split(' ');
+  get(square) {
+    return this.ch.get(square) || null;
+  }
+
+  legalMovesFrom(square, color = null) {
+    try {
+      if (!color || color === this.ch.turn()) {
+        return this.ch.moves({ square, verbose: true }).map((m) => m.to);
+      }
+      const parts = this.ch.fen().split(" ");
+      parts[1] = color;
+      const temp = new Chess(parts.join(" "));
+      return temp.moves({ square, verbose: true }).map((m) => m.to);
+    } catch {
+      return [];
+    }
+  }
+
+  premoveLegalMovesFrom(square, color) {
+    const piece = this.get(square);
+    if (!piece || (color && piece.color !== color)) return [];
+    if (!color || color === this.ch.turn()) {
+      return this.legalMovesFrom(square, color);
+    }
+    const baseFenParts = this.ch.fen().split(" ");
     baseFenParts[1] = color;
-    const baseFen = baseFenParts.join(' ');
-    for (const row of this.ch.board()){
-      for (const piece of row){
-        if (piece && piece.color === color && piece.square !== square){
+    const baseFen = baseFenParts.join(" ");
+    const kingSq = this.ch
+      .board()
+      .flat()
+      .find((p) => p && p.type === "k" && p.color === color)?.square;
+    const base = new Chess(baseFen);
+    if (kingSq) base.remove(kingSq);
+    const moves = new Set(
+      base.moves({ square, verbose: true, legal: false }).map((m) => m.to),
+    );
+    for (const row of this.ch.board()) {
+      for (const p of row) {
+        if (p && p.color === color && p.square !== square) {
           const temp = new Chess(baseFen);
-          temp.remove(piece.square);
-          const mvs = temp.moves({ square, verbose: true }).map(m => m.to);
-          if (mvs.includes(piece.square)) moves.add(piece.square);
+          if (kingSq) temp.remove(kingSq);
+          temp.remove(p.square);
+          const mvs = temp
+            .moves({ square, verbose: true, legal: false })
+            .map((m) => m.to);
+          if (mvs.includes(p.square)) moves.add(p.square);
         }
       }
     }
     return Array.from(moves);
   }
 
-  move(obj){ const m = this.ch.move(obj); if (m) this.redo.length = 0; return m; }
-  moveUci(uci){
-    const m = uci.match(/^([a-h][1-8])([a-h][1-8])([qrbn])?$/); if (!m) return null;
-    return this.move({ from:m[1], to:m[2], promotion:m[3]||undefined });
+  move(obj) {
+    const m = this.ch.move(obj);
+    if (m) this.redo.length = 0;
+    return m;
   }
-  moveSan(san){ const m = this.ch.move(san); if (m) this.redo.length = 0; return m; }
-  undo(){ const u = this.ch.undo(); if (u) this.redo.push(u); return u; }
-  redoOne(){ const u = this.redo.pop(); if (!u) return null; this.ch.move(u); return u; }
+  moveUci(uci) {
+    const m = uci.match(/^([a-h][1-8])([a-h][1-8])([qrbn])?$/);
+    if (!m) return null;
+    return this.move({ from: m[1], to: m[2], promotion: m[3] || undefined });
+  }
+  moveSan(san) {
+    const m = this.ch.move(san);
+    if (m) this.redo.length = 0;
+    return m;
+  }
+  undo() {
+    const u = this.ch.undo();
+    if (u) this.redo.push(u);
+    return u;
+  }
+  redoOne() {
+    const u = this.redo.pop();
+    if (!u) return null;
+    this.ch.move(u);
+    return u;
+  }
 }
-

--- a/tests/premove.test.js
+++ b/tests/premove.test.js
@@ -1,26 +1,36 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { Game } from '../chess-website-uml/public/src/core/Game.js';
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Game } from "../chess-website-uml/public/src/core/Game.js";
 
-test('queued pre-move executes after opponent move', async () => {
+test("queued pre-move executes after opponent move", async () => {
   globalThis.document = {
-    getElementById() { return null; },
+    getElementById() {
+      return null;
+    },
     createElement() {
-      return { setAttribute() {}, appendChild() {}, style: {}, textContent: '', id: '' };
+      return {
+        setAttribute() {},
+        appendChild() {},
+        style: {},
+        textContent: "",
+        id: "",
+      };
     },
     head: { appendChild() {} },
-    querySelector() { return null; }
+    querySelector() {
+      return null;
+    },
   };
   globalThis.window = { addEventListener() {}, dispatchEvent() {} };
-  const { App } = await import('../chess-website-uml/public/src/app/App.js');
+  const { App } = await import("../chess-website-uml/public/src/app/App.js");
   const app = Object.create(App.prototype);
   app.game = new Game();
-  app.modeSel = { value: 'play' };
-  app.sideSel = { value: 'white' };
+  app.modeSel = { value: "play" };
+  app.sideSel = { value: "white" };
   app.inReview = false;
   app.gameOver = false;
   app.preMove = null;
-  app.clock = { onMoveApplied() {}, turn: 'w', white: 0, black: 0, inc: 0 };
+  app.clock = { onMoveApplied() {}, turn: "w", white: 0, black: 0, inc: 0 };
   app.clockPanel = { startIfNotRunning() {} };
   app.ui = { clearArrow() {} };
   app.playMoveSound = () => {};
@@ -35,48 +45,58 @@ test('queued pre-move executes after opponent move', async () => {
   app.getPieceAt = App.prototype.getPieceAt.bind(app);
   app.getLegalTargets = App.prototype.getLegalTargets.bind(app);
 
-  app.game.load('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1');
+  app.game.load("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1");
 
-  const startPiece = app.getPieceAt('e2');
-  assert.equal(startPiece?.type, 'p');
-  const targets = app.getLegalTargets('e2').sort();
-  assert.deepEqual(targets, ['e3', 'e4']);
+  const startPiece = app.getPieceAt("e2");
+  assert.equal(startPiece?.type, "p");
+  const targets = app.getLegalTargets("e2").sort();
+  assert.deepEqual(targets, ["e3", "e4"]);
 
-  const ok = app.onUserMove({ from: 'e2', to: 'e4' });
+  const ok = app.onUserMove({ from: "e2", to: "e4" });
   assert.equal(ok, true);
-  assert.deepEqual(app.preMove, { from: 'e2', to: 'e4', promotion: 'q' });
-  assert.equal(app.game.get('e2').type, 'p');
-  assert.equal(app.game.turn(), 'b');
+  assert.deepEqual(app.preMove, { from: "e2", to: "e4", promotion: "q" });
+  assert.equal(app.game.get("e2").type, "p");
+  assert.equal(app.game.turn(), "b");
 
-  app.game.moveUci('e7e5');
+  app.game.moveUci("e7e5");
   app.applyPreMove();
 
   assert.equal(app.preMove, null);
-  const piece = app.game.get('e4');
-  assert.equal(piece.color, 'w');
-  assert.equal(app.game.get('e2'), null);
-  assert.equal(app.game.turn(), 'b');
+  const piece = app.game.get("e4");
+  assert.equal(piece.color, "w");
+  assert.equal(app.game.get("e2"), null);
+  assert.equal(app.game.turn(), "b");
 });
 
-test('queued pre-move can target own piece square for recapture', async () => {
+test("queued pre-move can target own piece square for recapture", async () => {
   globalThis.document = {
-    getElementById() { return null; },
+    getElementById() {
+      return null;
+    },
     createElement() {
-      return { setAttribute() {}, appendChild() {}, style: {}, textContent: '', id: '' };
+      return {
+        setAttribute() {},
+        appendChild() {},
+        style: {},
+        textContent: "",
+        id: "",
+      };
     },
     head: { appendChild() {} },
-    querySelector() { return null; }
+    querySelector() {
+      return null;
+    },
   };
   globalThis.window = { addEventListener() {}, dispatchEvent() {} };
-  const { App } = await import('../chess-website-uml/public/src/app/App.js');
+  const { App } = await import("../chess-website-uml/public/src/app/App.js");
   const app = Object.create(App.prototype);
   app.game = new Game();
-  app.modeSel = { value: 'play' };
-  app.sideSel = { value: 'white' };
+  app.modeSel = { value: "play" };
+  app.sideSel = { value: "white" };
   app.inReview = false;
   app.gameOver = false;
   app.preMove = null;
-  app.clock = { onMoveApplied() {}, turn: 'w', white: 0, black: 0, inc: 0 };
+  app.clock = { onMoveApplied() {}, turn: "w", white: 0, black: 0, inc: 0 };
   app.clockPanel = { startIfNotRunning() {} };
   app.ui = { clearArrow() {} };
   app.playMoveSound = () => {};
@@ -91,22 +111,30 @@ test('queued pre-move can target own piece square for recapture', async () => {
   app.getPieceAt = App.prototype.getPieceAt.bind(app);
   app.getLegalTargets = App.prototype.getLegalTargets.bind(app);
 
-  app.game.load('4k3/8/8/4p3/3P4/2Q5/8/4K3 b - - 0 1');
+  app.game.load("4k3/8/8/4p3/3P4/2Q5/8/4K3 b - - 0 1");
 
-  const targets = app.getLegalTargets('c3').sort();
-  assert.ok(targets.includes('d4'));
+  const targets = app.getLegalTargets("c3").sort();
+  assert.ok(targets.includes("d4"));
 
-  const ok = app.onUserMove({ from: 'c3', to: 'd4' });
+  const ok = app.onUserMove({ from: "c3", to: "d4" });
   assert.equal(ok, true);
-  assert.deepEqual(app.preMove, { from: 'c3', to: 'd4', promotion: 'q' });
-  assert.equal(app.game.get('c3').type, 'q');
+  assert.deepEqual(app.preMove, { from: "c3", to: "d4", promotion: "q" });
+  assert.equal(app.game.get("c3").type, "q");
 
-  app.game.moveUci('e5d4');
+  app.game.moveUci("e5d4");
   app.applyPreMove();
 
   assert.equal(app.preMove, null);
-  const piece = app.game.get('d4');
-  assert.equal(piece?.color, 'w');
-  assert.equal(piece?.type, 'q');
-  assert.equal(app.game.get('c3'), null);
+  const piece = app.game.get("d4");
+  assert.equal(piece?.color, "w");
+  assert.equal(piece?.type, "q");
+  assert.equal(app.game.get("c3"), null);
+});
+
+test("premove can move pinned piece and cannot move opponent piece", () => {
+  const game = new Game();
+  game.load("4k3/4q3/8/8/8/8/8/K3R3 w - - 0 1");
+  const preMoves = game.premoveLegalMovesFrom("e7", "b");
+  assert.ok(preMoves.includes("d6"));
+  assert.deepEqual(game.premoveLegalMovesFrom("e1", "b"), []);
 });


### PR DESCRIPTION
## Summary
- allow premoves that ignore check by generating pseudo-legal moves without the player's king
- prevent premoving with opponent pieces
- test coverage for pinned piece moves and opponent piece restriction

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a732694348832e8bd9453806808a41