### PR TITLE
fix: use opening book on first move

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -589,7 +589,11 @@ export class App {
   // === Opening book: ask boot.js for a SAN move before calling the engine
   askBookMove() {
     return new Promise((resolve) => {
-      const onMove = (ev) => resolve(ev?.detail?.san || null);
+      let timeout;
+      const onMove = (ev) => {
+        clearTimeout(timeout);
+        resolve(ev?.detail?.san || null);
+      };
       window.addEventListener("book-move", onMove, { once: true });
       const hist = this.getSanHistory();
       window.dispatchEvent(
@@ -601,7 +605,10 @@ export class App {
           },
         }),
       );
-      setTimeout(() => resolve(null), 25); // tolerate missing listener
+      timeout = setTimeout(() => {
+        window.removeEventListener("book-move", onMove);
+        resolve(null);
+      }, 200); // tolerate missing listener
     });
   }
 

--- a/src/engine/openingsECO.json
+++ b/src/engine/openingsECO.json
@@ -1,5 +1,11 @@
 [
   {
+    "eco": "C30",
+    "name": "King's Gambit Accepted",
+    "san": "e4 e5 f4 exf4",
+    "fen": "rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPP2PP/RNBQKBNR w KQkq - 0 3"
+  },
+  {
     "eco": "C67",
     "name": "Ruy Lopez: Berlin Defense, Rio Gambit Accepted",
     "san": "e4 e5 Nf3 Nc6 Bb5 Nf6 O-O Nxe4 Re1 Nd6 Nxe5 Be7 Bf1 Nxe5 Rxe5 O-O",

--- a/tests/openings.test.js
+++ b/tests/openings.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { detectOpening } from "../src/engine/Openings.js";
+
+test("detectOpening recognizes King's Gambit Accepted", () => {
+  const san = ["e4", "e5", "f4", "exf4"];
+  const fen = "rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPP2PP/RNBQKBNR w KQkq - 0 3";
+  const opening = detectOpening({ san, fen });
+  assert.deepEqual(opening, {
+    eco: "C30",
+    name: "King's Gambit Accepted",
+  });
+});


### PR DESCRIPTION
## Summary
- ensure opening-book handshake waits for the book to load
- register King's Gambit Accepted in the ECO dataset and test its detection

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7336dcc50832ea3cb2aa362be0944