### PR TITLE
feat: add delay for opening book moves

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -620,6 +620,9 @@ export class App {
       // 1) Try the opening book first
       const san = await this.askBookMove();
       if (san) {
+        // Delay book moves slightly to mimic thinking time
+        const delay = 500 + Math.random() * 1000;
+        await new Promise((r) => setTimeout(r, delay));
         const mv = this.game.moveSan(san);
         if (mv) {
           this.clock.onMoveApplied?.();


### PR DESCRIPTION
## Summary
- add randomized delay before executing opening book moves to mimic thinking time

## Testing
- `npx prettier --write src/app/App.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7365b9d20832e8ec476411e8e4558