### PR TITLE
Handle extreme engine evals in analysis

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -8,6 +8,7 @@ import { ClockPanel } from "../ui/ClockPanel.js";
 import { detectOpening } from "../engine/Openings.js";
 import { Chess } from "../vendor/chess.mjs";
 import { Sounds } from "../util/Sounds.js";
+import { formatScore } from "../util/format.js";
 
 const qs = (s) => document.querySelector(s);
 
@@ -692,7 +693,7 @@ export class App {
       this.pvBox.innerHTML = (lines || [])
         .map(
           (it, i) =>
-            `<div>PV${i + 1}: <b>${(it.scoreCp / 100).toFixed(2)}</b> — <span class="muted">${(it.san || []).join(" ")}</span></div>`,
+            `<div>PV${i + 1}: <b>${formatScore(it.scoreCp)}</b> — <span class="muted">${(it.san || []).join(" ")}</span></div>`,
         )
         .join("");
     } catch (e) {
@@ -720,6 +721,7 @@ export class App {
   }
 
   updateEvalFromCp(cp) {
+    if (!Number.isFinite(cp) || Math.abs(cp) >= 1e7) return;
     const clamped = Math.max(-1000, Math.min(1000, cp | 0));
     const pct = 50 + clamped / 20;
     this.evalbar.style.display = "block";

--- a/src/util/format.js
+++ b/src/util/format.js
@@ -1,12 +1,26 @@
 export const formatTime = (ms) => {
-  const s = Math.max(0, Math.floor(ms/1000));
-  const m = Math.floor(s/60), r = s%60;
-  return `${String(m).padStart(2,'0')}:${String(r).padStart(2,'0')}`;
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(s / 60),
+    r = s % 60;
+  return `${String(m).padStart(2, "0")}:${String(r).padStart(2, "0")}`;
 };
 
 // Simple logistic to convert centipawns to [0..1] win-prob-like bar (rough)
-export function scoreToPct(cp, sideToMove){
-  const p = 1/(1+Math.exp(-cp/120));
-  return (sideToMove === 'w') ? p : (1-p);
+export function scoreToPct(cp, sideToMove) {
+  const p = 1 / (1 + Math.exp(-cp / 120));
+  return sideToMove === "w" ? p : 1 - p;
 }
 
+export const MATE_SCORE = 1e7;
+export const INF_SCORE = 1e9;
+
+export function formatScore(cp) {
+  if (!Number.isFinite(cp)) return "?";
+  if (Math.abs(cp) >= INF_SCORE) return "∞";
+  if (Math.abs(cp) > MATE_SCORE - 1000) {
+    const ply = MATE_SCORE - Math.abs(cp);
+    const moves = Math.ceil(ply / 2);
+    return `${cp > 0 ? "#" : "#-"}${moves}`;
+  }
+  return (cp / 100).toFixed(2);
+}

--- a/tests/formatScore.test.js
+++ b/tests/formatScore.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatScore,
+  MATE_SCORE,
+  INF_SCORE,
+} from "../chess-website-uml/public/src/util/format.js";
+
+test("formatScore handles centipawns", () => {
+  assert.equal(formatScore(123), "1.23");
+});
+
+test("formatScore handles mate scores", () => {
+  assert.equal(formatScore(MATE_SCORE - 1), "#1");
+  assert.equal(formatScore(-MATE_SCORE + 1), "#-1");
+});
+
+test("formatScore handles infinite scores", () => {
+  assert.equal(formatScore(INF_SCORE), "∞");
+});


### PR DESCRIPTION
## Summary
- avoid huge numbers from engine by formatting evals and skipping invalid values
- add util to format centipawn scores, including mate and infinity cases
- test score formatting helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7369e5a10832ebbc1e9c913333ace