### PR TITLE
feat: add secret brown mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,19 @@
         text-align: center;
         font-size: 13px;
         color: var(--muted);
+        position: relative;
       }
       footer.site-footer a {
         color: var(--accent);
+      }
+
+      footer.site-footer .secret-btn {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        width: 20px;
+        height: 20px;
+        opacity: 0;
       }
 
       /* Board section first; controls below (single column) */
@@ -752,6 +762,11 @@
           Contact:
           <a href="mailto:itsjustme@samzlotnik.se">itsjustme@samzlotnik.se</a>
         </p>
+        <button
+          id="secretMode"
+          class="secret-btn"
+          aria-label="Activate secret mode"
+        ></button>
       </footer>
     </div>
 
@@ -761,5 +776,36 @@
     <script src="./src/ui/DrawOverlay.js" defer></script>
     <script src="./src/ui/SysArrowPolicy.js" defer></script>
     <script src="./src/ui/MoveFlash.js" defer></script>
+    <script>
+      const secretBtn = document.getElementById("secretMode");
+      window.secretMode = false;
+      secretBtn?.addEventListener("click", () => {
+        const root = document.documentElement;
+        const brown = {
+          "--bg": "#3b2f2f",
+          "--layer": "#4e3d33",
+          "--muted": "#a58b6d",
+          "--text": "#f3e5d0",
+          "--square-dark": "#5c4735",
+          "--square-light": "#7a5d3e",
+          "--hl": "#d1a679",
+          "--accent": "#b3875c",
+          "--good": "#c19a6b",
+          "--bad": "#8b5a2b",
+        };
+        const active = root.dataset.secret === "1";
+        if (!active) {
+          Object.entries(brown).forEach(([k, v]) => {
+            root.style.setProperty(k, v);
+          });
+          root.dataset.secret = "1";
+          window.secretMode = true;
+        } else {
+          Object.keys(brown).forEach((k) => root.style.removeProperty(k));
+          delete root.dataset.secret;
+          window.secretMode = false;
+        }
+      });
+    </script>
   </body>
 </html>

--- a/src/util/Sounds.js
+++ b/src/util/Sounds.js
@@ -26,7 +26,16 @@ export class Sounds {
           type: "triangle",
         },
       };
-      const p = profiles[name] || profiles.move;
+
+      const fartProfiles = [
+        { filter: 180, osc: 60, dur: 0.8, gain: 0.28, type: "sawtooth" },
+        { filter: 150, osc: 50, dur: 0.9, gain: 0.3, type: "square" },
+        { filter: 220, osc: 70, dur: 0.6, gain: 0.25, type: "triangle" },
+      ];
+
+      const p = window.secretMode
+        ? fartProfiles[Math.floor(Math.random() * fartProfiles.length)]
+        : profiles[name] || profiles.move;
 
       const gain = ctx.createGain();
       const maxGain = p.gain ?? 0.09;


### PR DESCRIPTION
## Summary
- add hidden secret mode button in the footer
- secret mode turns theme brown and swaps sounds for wetter fart noises
- default sounds unchanged when secret mode off

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73a777a98832e81ed996567be0710