### PR TITLE
Use win probability for analysis bar

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -8,7 +8,7 @@ import { ClockPanel } from "../ui/ClockPanel.js";
 import { detectOpening } from "../engine/Openings.js";
 import { Chess } from "../vendor/chess.mjs";
 import { Sounds } from "../util/Sounds.js";
-import { formatScore } from "../util/format.js";
+import { formatScore, scoreToPct } from "../util/format.js";
 
 const qs = (s) => document.querySelector(s);
 
@@ -722,8 +722,7 @@ export class App {
 
   updateEvalFromCp(cp) {
     if (!Number.isFinite(cp) || Math.abs(cp) >= 1e7) return;
-    const clamped = Math.max(-1000, Math.min(1000, cp | 0));
-    const pct = 50 + clamped / 20;
+    const pct = scoreToPct(cp, this.game.turn()) * 100;
     this.evalbar.style.display = "block";
     this.evalWhite.style.height = `${Math.max(0, Math.min(100, pct))}%`;
     this.evalBlack.style.height = `${Math.max(0, Math.min(100, 100 - pct))}%`;

--- a/tests/scoreToPct.test.js
+++ b/tests/scoreToPct.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { scoreToPct } from "../chess-website-uml/public/src/util/format.js";
+
+test("scoreToPct is 0.5 for equal positions", () => {
+  assert.equal(scoreToPct(0, "w"), 0.5);
+  assert.equal(scoreToPct(0, "b"), 0.5);
+});
+
+test("scoreToPct accounts for side to move", () => {
+  const whiteAdv = scoreToPct(100, "w");
+  const blackAdv = scoreToPct(100, "b");
+  assert.ok(whiteAdv > 0.5);
+  assert.ok(blackAdv < 0.5);
+});


### PR DESCRIPTION
## Summary
- Base eval bar on `scoreToPct` so analysis reflects side-to-move win chances
- Add unit tests covering `scoreToPct`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73d01f890832e8709df408b7337e7