### PR TITLE
Allow deselecting a piece with a second click

### DIFF
--- a/src/ui/BoardUI.js
+++ b/src/ui/BoardUI.js
@@ -856,8 +856,9 @@ export class BoardUI {
 
       if (this.selected === sq) {
         this.clearSelectionDots();
+        this.squareEl(this.selected)?.classList?.remove("sel");
+        this.dragTargets.clear();
         this.selected = null;
-        this.dragTargets = new Set();
         return;
       }
 


### PR DESCRIPTION
## Summary
- allow clicking an already selected piece to clear its legal move indicators

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73e212988832e9bb13975761837a7