### PR TITLE
Avoid infinite engine scores after aborted search

### DIFF
--- a/src/workers/mini-engine.js
+++ b/src/workers/mini-engine.js
@@ -568,7 +568,7 @@ function search(ch, depth, alpha, beta, ply) {
       return { score: s, pv: [], best: tte.best };
   }
 
-  if (stopFlag || timeUp()) return { score: alpha, pv: [], best: null };
+  if (stopFlag || timeUp()) return { score: evalBoard(ch), pv: [], best: null };
 
   const inChk = inCheck(ch);
 

--- a/src/workers/strong-engine.js
+++ b/src/workers/strong-engine.js
@@ -573,7 +573,7 @@ function search(ch, depth, alpha, beta, ply) {
       return { score: s, pv: [], best: tte.best };
   }
 
-  if (stopFlag || timeUp()) return { score: alpha, pv: [], best: null };
+  if (stopFlag || timeUp()) return { score: evalBoard(ch), pv: [], best: null };
 
   const inChk = inCheck(ch);
 


### PR DESCRIPTION
## Summary
- Return a static board evaluation when the engine search is stopped early to avoid `∞` results.
- Apply fix to both strong and mini engine workers so eval bar receives finite scores.

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73dd0e640832ea0cf79616961af07