### PR TITLE
Stream analysis updates for smoother eval bar

### DIFF
--- a/css/board.css
+++ b/css/board.css
@@ -181,11 +181,13 @@ svg.arrow {
   background: #f2f5f8;
   width: 100%;
   height: 50%;
+  transition: height 0.2s linear;
 }
-evalbar .black {
+.evalbar .black {
   background: #0c0f14;
   width: 100%;
   height: 50%;
+  transition: height 0.2s linear;
 }
 
 /* Promotion */

--- a/index.html
+++ b/index.html
@@ -302,11 +302,13 @@
         background: #f2f5f8;
         width: 100%;
         height: 50%;
+        transition: height 0.2s linear;
       }
       .evalbar .black {
         background: #0c0f14;
         width: 100%;
         height: 50%;
+        transition: height 0.2s linear;
       }
 
       /* Promotion */

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -682,6 +682,9 @@ export class App {
         depth: parseInt(this.depth.value, 10),
         multipv: parseInt(this.multipv.value, 10),
         timeMs: window.engineTuner?.lastMovetime || 300,
+        onProgress: (ls) => {
+          if (ls && ls[0]) this.updateEvalFromCp(ls[0].scoreCp);
+        },
       });
       this.ui.clearArrow?.();
       (lines || []).forEach((l, i) => {
@@ -710,6 +713,9 @@ export class App {
         depth: Math.max(2, parseInt(this.depth.value, 10)),
         multipv: 1,
         timeMs: window.engineTuner?.lastMovetime || 300,
+        onProgress: (ls) => {
+          if (ls && ls[0]) this.updateEvalFromCp(ls[0].scoreCp);
+        },
       });
       if (lines && lines[0]?.firstUci) this.ui.drawArrowUci(lines[0].firstUci);
       if (lines && lines[0]) this.updateEvalFromCp(lines[0].scoreCp);

--- a/src/workers/mini-engine.js
+++ b/src/workers/mini-engine.js
@@ -692,7 +692,7 @@ function search(ch, depth, alpha, beta, ply) {
 }
 
 // Root iterative deepening with aspiration windows
-function analyzeRoot(fen, depth, multipv) {
+function analyzeRoot(fen, depth, multipv, id) {
   killers.length = 0;
   history.clear();
 
@@ -705,6 +705,7 @@ function analyzeRoot(fen, depth, multipv) {
 
   let scores = new Map();
   let bestSoFar = 0;
+  let lines = [];
 
   for (let d = 1; d <= depth && !stopFlag && !timeUp(); d++) {
     let A = -INF,
@@ -739,28 +740,31 @@ function analyzeRoot(fen, depth, multipv) {
       if (sc > localBest) localBest = sc;
     }
     bestSoFar = localBest;
-  }
 
-  const ranked = [...scores.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, Math.max(1, multipv | 0));
-  const lines = [];
-  for (const [uci, _sc] of ranked) {
-    root.move({
-      from: uci.slice(0, 2),
-      to: uci.slice(2, 4),
-      promotion: uci[4],
-    });
-    const child = search(root, Math.max(0, depth - 1), -INF, INF, 1);
-    root.undo();
-    const pv = [uci].concat(child.pv || []);
-    lines.push({
-      firstUci: uci,
-      scoreCp: -child.score | 0,
-      pv,
-      san: pvToSan(fen, pv),
-    });
-    if (stopFlag || timeUp()) break;
+    const ranked = [...scores.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, Math.max(1, multipv | 0));
+    lines = [];
+    for (const [uci, _sc] of ranked) {
+      root.move({
+        from: uci.slice(0, 2),
+        to: uci.slice(2, 4),
+        promotion: uci[4],
+      });
+      const child = search(root, Math.max(0, d - 1), -INF, INF, 1);
+      root.undo();
+      const pv = [uci].concat(child.pv || []);
+      lines.push({
+        firstUci: uci,
+        scoreCp: -child.score | 0,
+        pv,
+        san: pvToSan(fen, pv),
+      });
+      if (stopFlag || timeUp()) break;
+    }
+    if (id !== undefined) {
+      postMessage({ type: "analysis", id, lines, depth: d });
+    }
   }
   return lines;
 }
@@ -797,8 +801,8 @@ onmessage = (e) => {
     stopFlag = false;
     const depth = Math.max(1, msg.depth | 0),
       k = Math.max(1, msg.multipv | 0);
-    const lines = analyzeRoot(msg.fen, depth, k);
-    postMessage({ type: "analysis", id: msg.id, lines, depth });
+    const lines = analyzeRoot(msg.fen, depth, k, msg.id);
+    postMessage({ type: "analysis", id: msg.id, lines, depth, final: true });
   } else if (msg.type === "play") {
     const d = Math.max(1, msg.depthCap | 0);
     const uci = chooseMoveForPlay(msg.fen, d, msg.elo | 0, msg.timeMs | 0);


### PR DESCRIPTION
## Summary
- stream engine analysis with progress callbacks so eval bar updates during search
- emit intermediate analysis messages from engine workers
- animate eval bar height for smooth transitions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a876ebbc08832ea183fc29e67b6f91