### PR TITLE
fix: prevent board text selection

### DIFF
--- a/css/board.css
+++ b/css/board.css
@@ -30,7 +30,9 @@
   border-radius: 12px;
   overflow: hidden;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
+  -webkit-touch-callout: none;
   cursor: grab;
 }
 
@@ -48,6 +50,8 @@
     "DejaVu Sans", "Noto Sans Symbols2", "Segoe UI Symbol", "Symbola",
     "FreeSerif", serif;
   font-variant-emoji: text;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .sq {

--- a/index.html
+++ b/index.html
@@ -169,8 +169,10 @@
         border-radius: 12px;
         overflow: hidden;
         touch-action: none;
-        cursor: grab;
+        -webkit-user-select: none;
         user-select: none;
+        -webkit-touch-callout: none;
+        cursor: grab;
       }
       .sq {
         position: relative;

--- a/src/ui/BoardUI.js
+++ b/src/ui/BoardUI.js
@@ -51,9 +51,10 @@ const BLACK_GLYPH = {
         var(--glyph-outline-width) calc(var(--glyph-outline-width) * -1) var(--glyph-outline, #000),
         calc(var(--glyph-outline-width) * -1) var(--glyph-outline-width) var(--glyph-outline, #000),
         calc(var(--glyph-outline-width) * -1)
-          calc(var(--glyph-outline-width) * -1)
+        calc(var(--glyph-outline-width) * -1)
           var(--glyph-outline, #000);
       pointer-events: none;
+      -webkit-user-select: none;
       user-select: none;
     }
     /* Make bishops slightly larger to distinguish from pawns */


### PR DESCRIPTION
## Summary
- disable text selection on the board and pieces to stop copy-highlighting on mobile

## Testing
- `npx prettier --write index.html src/ui/BoardUI.js css/board.css`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8776aca30832eb4a2a5f65740af15