### PR TITLE
feat: add varied celebrations

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -12,6 +12,19 @@ import { formatScore, scoreToPct } from "../util/format.js";
 
 const qs = (s) => document.querySelector(s);
 
+export const CELEBRATION_SOUNDS = [
+  "airhorn",
+  "boom",
+  "kazoo",
+  "airhorn",
+  "boom",
+  "airhorn",
+  "kazoo",
+  "airhorn",
+  "kazoo",
+  "airhorn",
+];
+
 export class App {
   constructor() {
     window.app = this;
@@ -914,12 +927,14 @@ export class App {
           }
         }
       } catch {}
-      this.sounds.play("airhorn");
-      this.ui.celebrate?.(kingSq);
+      const idx = Math.floor(Math.random() * CELEBRATION_SOUNDS.length);
+      this.sounds.play(CELEBRATION_SOUNDS[idx]);
+      this.ui.celebrate?.(kingSq, idx);
     } else if (solvedPuzzle && this.lastCelebrationPly !== ply) {
       this.lastCelebrationPly = ply;
-      this.sounds.play("airhorn");
-      this.ui.celebrate?.();
+      const idx = Math.floor(Math.random() * CELEBRATION_SOUNDS.length);
+      this.sounds.play(CELEBRATION_SOUNDS[idx]);
+      this.ui.celebrate?.(undefined, idx);
     }
   }
 }

--- a/src/ui/BoardUI.js
+++ b/src/ui/BoardUI.js
@@ -115,8 +115,8 @@ const BLACK_GLYPH = {
     svg#arrowSvg g.analysis line.arrow { stroke-width: 6; stroke-linecap: round; opacity: .9; }
     svg#arrowSvg g.analysis polygon.head { opacity: .95; }
 
-    /* Celebration confetti */
-    .confetti-root { position:absolute; inset:0; overflow:visible; pointer-events:none; z-index:5; }
+    /* Celebrations */
+    .celebration-root { position:absolute; inset:0; overflow:visible; pointer-events:none; z-index:5; }
     .confetti-piece {
       position:absolute;
       width:12px; height:12px;
@@ -124,8 +124,34 @@ const BLACK_GLYPH = {
       transform: translate(-50%, -50%);
       animation: confetti-explode 1.2s ease-out forwards;
     }
+    .emoji-piece {
+      position:absolute;
+      font-size:24px;
+      transform: translate(-50%, -50%);
+      animation: confetti-explode 1.2s ease-out forwards;
+    }
+    .explosion-piece {
+      position:absolute;
+      width:8px; height:8px;
+      border-radius:50%;
+      background:#ffcf00;
+      transform: translate(-50%, -50%) scale(0);
+      animation: boom-explode .8s ease-out forwards;
+    }
+    .kazoo {
+      position:absolute;
+      font-size:36px;
+      transform: translate(-50%, -50%);
+      animation: kazoo-fly 1s ease-out forwards;
+    }
     @keyframes confetti-explode {
       to { transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))); opacity:0; }
+    }
+    @keyframes boom-explode {
+      to { transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(2); opacity:0; }
+    }
+    @keyframes kazoo-fly {
+      to { transform: translate(calc(-50% + 120px), calc(-50% - 40px)) rotate(20deg); opacity:0; }
     }
   `;
   document.head.appendChild(st);
@@ -255,6 +281,111 @@ function findKingSquare(pos, color) {
   }
   return null;
 }
+
+// -------- celebration builders --------
+function confettiBurst(root, origin) {
+  const colors = ["#e74c3c", "#f1c40f", "#2ecc71", "#3498db", "#9b59b6"];
+  for (let i = 0; i < 200; i++) {
+    const piece = document.createElement("div");
+    piece.className = "confetti-piece";
+    piece.style.left = `${origin.x}px`;
+    piece.style.top = `${origin.y}px`;
+    piece.style.backgroundColor =
+      colors[Math.floor(Math.random() * colors.length)];
+    const angle = Math.random() * Math.PI * 2;
+    const distance = 120 + Math.random() * 160;
+    piece.style.setProperty("--dx", `${Math.cos(angle) * distance}px`);
+    piece.style.setProperty("--dy", `${Math.sin(angle) * distance}px`);
+    piece.style.animationDelay = (Math.random() * 0.2).toFixed(2) + "s";
+    root.appendChild(piece);
+  }
+}
+
+function explosionBurst(root, origin) {
+  for (let i = 0; i < 60; i++) {
+    const piece = document.createElement("div");
+    piece.className = "explosion-piece";
+    piece.style.left = `${origin.x}px`;
+    piece.style.top = `${origin.y}px`;
+    const angle = Math.random() * Math.PI * 2;
+    const distance = 60 + Math.random() * 100;
+    piece.style.setProperty("--dx", `${Math.cos(angle) * distance}px`);
+    piece.style.setProperty("--dy", `${Math.sin(angle) * distance}px`);
+    root.appendChild(piece);
+  }
+}
+
+function kazooFly(root, origin) {
+  const piece = document.createElement("div");
+  piece.className = "kazoo";
+  piece.textContent = "🎺";
+  piece.style.left = `${origin.x}px`;
+  piece.style.top = `${origin.y}px`;
+  root.appendChild(piece);
+}
+
+function emojiBurst(root, origin, emojis, count, velocityFn) {
+  for (let i = 0; i < count; i++) {
+    const piece = document.createElement("div");
+    piece.className = "emoji-piece";
+    piece.textContent = emojis[Math.floor(Math.random() * emojis.length)];
+    piece.style.left = `${origin.x}px`;
+    piece.style.top = `${origin.y}px`;
+    const angle = Math.random() * Math.PI * 2;
+    const distance = 80 + Math.random() * 120;
+    const vel = velocityFn
+      ? velocityFn(angle, distance)
+      : { dx: Math.cos(angle) * distance, dy: Math.sin(angle) * distance };
+    piece.style.setProperty("--dx", `${vel.dx}px`);
+    piece.style.setProperty("--dy", `${vel.dy}px`);
+    piece.style.animationDelay = (Math.random() * 0.2).toFixed(2) + "s";
+    root.appendChild(piece);
+  }
+}
+
+function starBurst(root, origin) {
+  emojiBurst(root, origin, ["★", "✦", "✧"], 40);
+}
+
+function heartBurst(root, origin) {
+  emojiBurst(root, origin, ["❤", "💖", "💗"], 40);
+}
+
+function pieceBurst(root, origin) {
+  emojiBurst(root, origin, Object.values(BLACK_GLYPH), 30);
+}
+
+function balloonRise(root, origin) {
+  emojiBurst(root, origin, ["🎈"], 20, () => ({
+    dx: (Math.random() - 0.5) * 80,
+    dy: -80 - Math.random() * 80,
+  }));
+}
+
+function sparkleBurst(root, origin) {
+  emojiBurst(root, origin, ["✨"], 40);
+}
+
+function noteBurst(root, origin) {
+  emojiBurst(root, origin, ["🎵", "🎶"], 30);
+}
+
+function smileBurst(root, origin) {
+  emojiBurst(root, origin, ["😆", "😁", "😄"], 30);
+}
+
+const CELEBRATION_BUILDERS = [
+  confettiBurst,
+  explosionBurst,
+  kazooFly,
+  starBurst,
+  heartBurst,
+  pieceBurst,
+  balloonRise,
+  sparkleBurst,
+  noteBurst,
+  smileBurst,
+];
 
 // --------------- BoardUI -----------------
 export class BoardUI {
@@ -989,32 +1120,23 @@ export class BoardUI {
   }
 
   // -------- celebration --------
-  celebrate(square) {
+  celebrate(
+    square,
+    type = Math.floor(Math.random() * CELEBRATION_BUILDERS.length),
+  ) {
     // remove any existing celebration
     this.stopCelebration();
 
     const root = document.createElement("div");
-    root.className = "confetti-root";
+    root.className = "celebration-root";
     this.boardEl.appendChild(root);
 
     const origin = square
       ? this.squareCenterPx(square)
       : { x: this.boardEl.clientWidth / 2, y: this.boardEl.clientHeight / 2 };
-    const colors = ["#e74c3c", "#f1c40f", "#2ecc71", "#3498db", "#9b59b6"];
-    for (let i = 0; i < 200; i++) {
-      const piece = document.createElement("div");
-      piece.className = "confetti-piece";
-      piece.style.left = `${origin.x}px`;
-      piece.style.top = `${origin.y}px`;
-      piece.style.backgroundColor =
-        colors[Math.floor(Math.random() * colors.length)];
-      const angle = Math.random() * Math.PI * 2;
-      const distance = 120 + Math.random() * 160;
-      piece.style.setProperty("--dx", `${Math.cos(angle) * distance}px`);
-      piece.style.setProperty("--dy", `${Math.sin(angle) * distance}px`);
-      piece.style.animationDelay = (Math.random() * 0.2).toFixed(2) + "s";
-      root.appendChild(piece);
-    }
+
+    const builder = CELEBRATION_BUILDERS[type] || CELEBRATION_BUILDERS[0];
+    builder(root, origin);
 
     this._celebrationRoot = root;
     this._celebrationTimer = setTimeout(() => this.stopCelebration(), 1500);

--- a/src/util/Sounds.js
+++ b/src/util/Sounds.js
@@ -25,6 +25,20 @@ export class Sounds {
           gain: 0.12,
           type: "triangle",
         },
+        boom: {
+          filter: 500,
+          osc: 120,
+          dur: 0.4,
+          gain: 0.15,
+          type: "square",
+        },
+        kazoo: {
+          filter: 1000,
+          osc: 220,
+          dur: 0.6,
+          gain: 0.12,
+          type: "sawtooth",
+        },
         fart: {
           filter: 200,
           osc: 80,

--- a/tests/puzzleCelebration.test.js
+++ b/tests/puzzleCelebration.test.js
@@ -22,7 +22,9 @@ globalThis.document = {
   head: { appendChild() {} },
 };
 
-const { App } = await import("../chess-website-uml/public/src/app/App.js");
+const { App, CELEBRATION_SOUNDS } = await import(
+  "../chess-website-uml/public/src/app/App.js"
+);
 
 test("celebrates when puzzle solved without mate", () => {
   const app = Object.create(App.prototype);
@@ -41,18 +43,21 @@ test("celebrates when puzzle solved without mate", () => {
   app.ui = {
     celebrated: false,
     square: undefined,
-    celebrate(sq) {
+    type: undefined,
+    celebrate(sq, t) {
       this.celebrated = true;
       this.square = sq;
+      this.type = t;
     },
   };
 
   App.prototype.maybeCelebrate.call(app);
 
-  assert.equal(app.sounds.played, "airhorn");
+  assert.ok(CELEBRATION_SOUNDS.includes(app.sounds.played));
   assert.equal(app.ui.celebrated, true);
   assert.equal(app.ui.square, undefined);
   assert.equal(app.lastCelebrationPly, 1);
+  assert.ok(app.ui.type >= 0 && app.ui.type < CELEBRATION_SOUNDS.length);
 });
 
 test("resets celebration state when puzzle loads", () => {


### PR DESCRIPTION
## Summary
- randomize between 10 celebration effects including confetti, explosions, kazoo and more
- add matching celebration sounds and expose sound list
- update puzzle celebration tests for new behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a79ce80832e99c6845955c6684f