### PR TITLE
Fix Puzzle Rush orientation by autoplaying opponent move

### DIFF
--- a/src/puzzles/PuzzleUI.js
+++ b/src/puzzles/PuzzleUI.js
@@ -549,7 +549,7 @@ export class PuzzleUI {
         this.finishRush("empty");
         return;
       }
-      await this.loadConvertedPuzzle({ ...p, autoplayFirst: false });
+      await this.loadConvertedPuzzle({ ...p, autoplayFirst: true });
       if (this.dom?.puzzleStatus)
         this.dom.puzzleStatus.innerHTML = `<span style="color:#8aa0b6">Your move…</span>`;
     } catch (e) {

--- a/tests/puzzleOrientation.test.js
+++ b/tests/puzzleOrientation.test.js
@@ -45,3 +45,50 @@ test("loadConvertedPuzzle flips orientation", async () => {
   assert.equal(oriented, "white");
   assert.equal(app.gameOver, false);
 });
+
+test("puzzle rush orients board for the player", async () => {
+  const game = new Game();
+  let oriented = null;
+  const app = {
+    sideSel: { value: "white" },
+    applyOrientation() {
+      ui.setOrientation(this.sideSel.value);
+    },
+  };
+  const ui = {
+    clearArrow() {},
+    resizeOverlay() {},
+    drawArrowUci() {},
+    setOrientation(side) {
+      oriented = side;
+    },
+  };
+  const puzzles = new PuzzleUI({
+    game,
+    ui,
+    service: {
+      async randomFiltered() {
+        return {
+          puzzle: {
+            id: "rush1",
+            fen: "r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+            moves: "d7d5 e4d5",
+          },
+        };
+      },
+    },
+    dom: {},
+    onStateChanged: () => {},
+    onMove: () => {},
+    onPuzzleLoad: (turn) => {
+      app.sideSel.value = turn === "w" ? "white" : "black";
+      app.applyOrientation();
+    },
+  });
+
+  puzzles.rushActive = true;
+  await puzzles.loadNextRushPuzzle();
+
+  assert.equal(app.sideSel.value, "white");
+  assert.equal(oriented, "white");
+});


### PR DESCRIPTION
## Summary
- ensure Puzzle Rush loads each puzzle after auto-playing the opening move so the solver keeps the correct color
- add a regression test that Puzzle Rush orients the board for the player's side

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd3f85e920832eaa3e9830b4fef099